### PR TITLE
feat(core): refactored instance creator and expose methods

### DIFF
--- a/packages/tres/src/core/useInstanceCreator/index.ts
+++ b/packages/tres/src/core/useInstanceCreator/index.ts
@@ -1,17 +1,15 @@
-import { OrthographicCamera } from 'three'
 /* eslint-disable new-cap */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Object3D, PerspectiveCamera } from 'three'
+import { OrthographicCamera, PerspectiveCamera } from 'three'
 import { defineComponent } from 'vue'
 import { isArray, isDefined, isFunction } from '@alvarosabu/utils'
 import { normalizeVectorFlexibleParam } from '/@/utils/normalize'
 import { useCamera, useScene } from '/@/core/'
 import { useLogger } from '/@/composables'
-import { TresCatalogue, TresInstance, TresVNode, TresVNodeType } from '../../types'
+import { TresAttributes, TresCatalogue, TresInstance, TresVNode, TresVNodeType } from '/@/types'
 
 const VECTOR3_PROPS = ['rotation', 'scale', 'position']
 
-type TresAttributes = Record<string, any> & { args?: number[] }
 export function useInstanceCreator(prefix: string) {
   const { logMessage, logError } = useLogger()
 

--- a/packages/tres/src/types/index.d.ts
+++ b/packages/tres/src/types/index.d.ts
@@ -10,3 +10,4 @@ export type TresVNodeType = VNodeTypes & {
   setup?: (props: Readonly<any>) => void
 }
 export type TresVNode = VNode & { children?: Array<VNode>; type: TresVNodeType }
+export type TresAttributes = Record<string, any> & { args?: number[] }


### PR DESCRIPTION
Hey @wheatjs I managed to refactor the instance creator, is way cleaner now and I also exposed the methods to create instances based on components or vnodes to be used for example in `cientos` package

How could we manage the component types to be used with  Volar? Any ideas?

Fixes #13 