### PR TITLE
fix(css): add better contrast on "Get started" on the homepage

### DIFF
--- a/docs/.vitepress/theme/config.css
+++ b/docs/.vitepress/theme/config.css
@@ -47,3 +47,7 @@
   text-decoration: dashed;
   font-weight: bold;
 }
+
+.VPButton.medium.brand {
+  color: var(--vp-button-alt-text);
+}


### PR DESCRIPTION
Just found that the contrast was quite subpar with the default setting.

<img width="224" alt="CleanShot 2023-01-10 at 19 01 21@2x" src="https://user-images.githubusercontent.com/5133074/211627552-75815e31-0513-4d80-8e8d-5a769df3c920.png">

Even without the devtools, it's quite hard to notice tbh.

Setting it to `--vp-button-alt-text` makes it far more readable IMO and complies with AAA.

<img width="226" alt="CleanShot 2023-01-10 at 19 02 18@2x" src="https://user-images.githubusercontent.com/5133074/211627708-10ad3f49-5a4a-4a5e-9306-093927b6c56a.png">

This is how it looks after the change.

<img width="671" alt="CleanShot 2023-01-10 at 19 03 11@2x" src="https://user-images.githubusercontent.com/5133074/211627936-de23879c-740f-423d-962d-58d5e30042c5.png">

---
I'm not sure if there was a better way to target this button (like a local CSS override). I've asked the [question here](https://github.com/vuejs/vitepress/issues/1540#issuecomment-1377642152).
In case it gets answered with a simpler approach, I'll stick to a change in `.vitepress/theme/config.css`. 👍🏻 