### PR TITLE
fix: correct casing of key names when pierced props

### DIFF
--- a/playground/src/components/VectorSetProps.vue
+++ b/playground/src/components/VectorSetProps.vue
@@ -14,9 +14,17 @@ const state = reactive({
   outputEncoding: sRGBEncoding,
   toneMapping: NoToneMapping,
 })
+
+const context = ref(null)
+
+watchEffect(() => {
+  if (context.value) {
+    console.log(context.value?.state?.scene)
+  }
+})
 </script>
 <template>
-  <TresCanvas v-bind="state">
+  <TresCanvas v-bind="state" ref="context">
     <TresPerspectiveCamera
       :position-x="5"
       :position-y="5"
@@ -36,7 +44,7 @@ const state = reactive({
       :rotation-x="Math.PI * 1.5"
       :rotation-y="Math.PI * 0.6"
       :rotation-z="Math.PI * 0.2"
-      :position-y="1"
+      :position-y="5"
       :position-z="-2"
       cast-shadow
     >

--- a/playground/src/pages/index.vue
+++ b/playground/src/pages/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts"></script>
 <template>
   <Suspense>
-    <TheEvents />
+    <VectorSetProps />
   </Suspense>
 </template>

--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -77,8 +77,8 @@ export const nodeOps: RendererOptions<TresObject, TresObject> = {
     if (node) {
       let root = node
       let key = prop
-      const camelKey = kebabToCamel(key)
-      let target = root?.[camelKey]
+      let finalKey = kebabToCamel(key)
+      let target = root?.[finalKey]
 
       if (!node.parent) {
         node.parent = scene as TresObject
@@ -97,7 +97,7 @@ export const nodeOps: RendererOptions<TresObject, TresObject> = {
         const chain = key.split('-')
         target = chain.reduce((acc, key) => acc[kebabToCamel(key)], root)
         key = chain.pop() as string
-
+        finalKey = key.toLowerCase()
         if (!target?.set) root = chain.reduce((acc, key) => acc[kebabToCamel(key)], root)
       }
       if (isOn(key)) {
@@ -107,11 +107,11 @@ export const nodeOps: RendererOptions<TresObject, TresObject> = {
       if (value === '') value = true
       // Set prop, prefer atomic methods if applicable
       if (isFunction(target)) {
-        if (Array.isArray(value)) node[camelKey](...value)
-        else node[camelKey](value)
+        if (Array.isArray(value)) node[finalKey](...value)
+        else node[finalKey](value)
         return
       }
-      if (!target?.set && !isFunction(target)) root[camelKey] = value
+      if (!target?.set && !isFunction(target)) root[finalKey] = value
       else if (target.constructor === value.constructor && target?.copy) target?.copy(value)
       else if (Array.isArray(value)) target.set(...value)
       else if (!target.isColor && target.setScalar) target.setScalar(value)


### PR DESCRIPTION
@Randysheng I was checking the issue and the PR, this approach will not require to specifically detect if props are `position, scale, rotation` ;) 