### PR TITLE
fix: avoid assigning args as BufferAttribute to BufferGeometry

### DIFF
--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -132,6 +132,7 @@ export const nodeOps: RendererOptions<TresObject, TresObject> = {
       let target = root?.[finalKey]
 
       if (root.type === 'BufferGeometry') {
+        if (key === 'args') return
         root.setAttribute(
           kebabToCamel(key),
           new BufferAttribute(...(nextValue as ConstructorParameters<typeof BufferAttribute>)),


### PR DESCRIPTION
close #229 