### PR TITLE
fix: message canvas 0 height false positives

### DIFF
--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -158,10 +158,12 @@ export function useRenderer(options: UseRendererOptions) {
   const { pause, resume } = useRenderLoop()
   const aspectRatio = computed(() => width.value / height.value)
 
-  if (!toValue(windowSize) && state.container?.value?.offsetHeight === 0) {
-    logWarning(`Oops... Seems like your canvas height is currently 0px, by default it takes the height of it's parent, so make sure it has some height with CSS.
-You could set windowSize=true to force the canvas to be the size of the window.`)
-  }
+  setTimeout(() => {
+    if (!toValue(windowSize) && !state.canvas.value.offsetHeight) {
+      logWarning(`Oops... Seems like your canvas height is currently 0px, it's posible that you couldn't watch your scene.
+  You could set windowSize=true to force the canvas to be the size of the window.`)
+    }
+  }, 1000)
 
   const updateRendererSize = () => {
     if (!renderer.value) {


### PR DESCRIPTION
I added a timeout is the fastest way to solve this issue, but also I changed the DOM element to the current canvas (not to the container) 
This because you can use something like
canvas{
position: absolute
height: 100vh
...
}
And render the scene but, the log appears because the container has 0 height

let me know

close #263 