### PR TITLE
docs: fix error in example code

### DIFF
--- a/docs/api/composables.md
+++ b/docs/api/composables.md
@@ -133,7 +133,7 @@ Then you can bind the textures to the material.
 <template>
   <TresCanvas>
     <TresMesh>
-      <TresMeshSphereGeometry />
+      <TresSphereGeometry />
       <TresMeshStandardMaterial
         :map="map"
         :displacementMap="displacementMap"


### PR DESCRIPTION
There was an obvious error in one of the examples that is fixed in this PR.
Just a simple copypaste error probably :)