### PR TITLE
feat: use render instead createApp

### DIFF
--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -7,7 +7,7 @@ import {
     type ShadowMapType,
     type ToneMapping,
 } from 'three'
-import { computed, h, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
+import { Fragment, computed, defineComponent, h, onMounted, provide, ref, shallowRef, watch, watchEffect } from 'vue'
 import { useTresContextProvider } from '../composables'
 import { render } from '../core/renderer'
 
@@ -17,7 +17,6 @@ import {
     useRenderLoop,
 } from '../composables'
 
-import { Fragment } from 'vue'
 import type { RendererPresetsType } from '../composables/useRenderer/const'
 import type { TresCamera, TresObject } from '../types/'
 
@@ -80,7 +79,13 @@ usePointerEventHandler({ scene: scene.value, contextParts: context })
 
 const renderScene = () => {
     const container = scene.value as unknown as TresObject
-    render(h(Fragment, null, slots && slots.default ? slots.default() : []), container)
+    const internalFnComponent = defineComponent({
+        setup() {
+            provide('useTres', context);
+            return () => h(Fragment, null, slots && slots.default ? slots.default() : [])
+        }
+    })
+    render(h(internalFnComponent), container)
 }
 
 

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -123,9 +123,10 @@ const addDefaultCamera = () => {
     }
 }
 
-watch(canvas, val => {
+const unwatch = watch(canvas, val => {
     if (!val) return
     triggerRef(scene)
+    unwatch?.()
 })
 
 watch(scene, () => {

--- a/src/composables/useCamera/index.ts
+++ b/src/composables/useCamera/index.ts
@@ -10,8 +10,9 @@ export const useCamera = ({ sizes, scene }: Pick<TresContext, 'sizes' | 'scene'>
     () => cameras.value[0],
   )
   // don't known why need manually trigger here
-  watch(camera, () => {
+  const unwatch = watch(camera, () => {
     triggerRef(cameras)
+    unwatch?.()
   }, { deep: true })
 
   const addCamera = (newCamera: Camera, active = false) => {

--- a/src/composables/useRaycaster/index.ts
+++ b/src/composables/useRaycaster/index.ts
@@ -1,5 +1,5 @@
 import { type Intersection, Object3D, Vector2 } from 'three'
-import { Ref, computed, onUnmounted } from 'vue'
+import { Ref, computed, onUnmounted, watchPostEffect } from 'vue'
 import { EventHook, createEventHook, useElementBounding, usePointer } from '@vueuse/core'
 
 import { type TresContext } from '../useTresContextProvider'
@@ -84,17 +84,20 @@ export const useRaycaster = (
 
   const onPointerLeave = (event: PointerEvent) => eventHookPointerMove.trigger({ event, intersects: [] })
 
-  canvas.value.addEventListener('pointerup', onPointerUp)
-  canvas.value.addEventListener('pointerdown', onPointerDown)
-  canvas.value.addEventListener('pointermove', onPointerMove)
-  canvas.value.addEventListener('pointerleave', onPointerLeave)
+  watchPostEffect(onCleanUp => {
+    if (!canvas.value) return
+    canvas.value.addEventListener('pointerup', onPointerUp)
+    canvas.value.addEventListener('pointerdown', onPointerDown)
+    canvas.value.addEventListener('pointermove', onPointerMove)
+    canvas.value.addEventListener('pointerleave', onPointerLeave)
+    onCleanUp(() => {
 
-  onUnmounted(() => {
-    if (!canvas?.value) return
-    canvas.value.removeEventListener('pointerup', onPointerUp)
-    canvas.value.removeEventListener('pointerdown', onPointerDown)
-    canvas.value.removeEventListener('pointermove', onPointerMove)
-    canvas.value.removeEventListener('pointerleave', onPointerLeave)
+      if (!canvas?.value) return
+      canvas.value.removeEventListener('pointerup', onPointerUp)
+      canvas.value.removeEventListener('pointerdown', onPointerDown)
+      canvas.value.removeEventListener('pointermove', onPointerMove)
+      canvas.value.removeEventListener('pointerleave', onPointerLeave)
+    })
   })
 
   return {

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -1,6 +1,6 @@
 import { Color, WebGLRenderer } from 'three'
 import { rendererPresets, RendererPresetsType } from './const'
-import { shallowRef, watchEffect, onUnmounted, type MaybeRef, computed, watch } from 'vue'
+import { shallowRef, watchEffect, onUnmounted, type MaybeRef, computed, watch, ShallowRef } from 'vue'
 import {
   toValue,
   unrefElement,
@@ -110,7 +110,7 @@ export function useRenderer(
   }:
     {
       canvas: MaybeRef<HTMLCanvasElement | undefined>
-      scene: Scene
+      scene: ShallowRef<Scene>
       options: UseRendererOptions
       contextParts: Pick<TresContext, 'sizes' | 'camera'>
       disableRender: MaybeRefOrGetter<boolean>
@@ -235,7 +235,7 @@ export function useRenderer(
 
   onLoop(() => {
     if (camera.value && !toValue(disableRender))
-      renderer.value.render(scene, camera.value)
+      renderer.value.render(scene.value, camera.value)
   })
 
   resume()

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -109,7 +109,7 @@ export function useRenderer(
     contextParts: { sizes, camera },
   }:
     {
-      canvas: MaybeRef<HTMLCanvasElement>
+      canvas: MaybeRef<HTMLCanvasElement | undefined>
       scene: Scene
       options: UseRendererOptions
       contextParts: Pick<TresContext, 'sizes' | 'camera'>

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -6,6 +6,7 @@ import { UseRendererOptions, useRenderer } from '../useRenderer';
 import { extend } from '../../core/catalogue';
 
 import type { ComputedRef, DeepReadonly, MaybeRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue';
+import { useLogger } from '../useLogger';
 
 export type TresContext = {
   scene: ShallowRef<Scene>;
@@ -30,16 +31,20 @@ export function useTresContextProvider({
   rendererOptions
 }: {
   scene: Scene,
-  canvas: MaybeRef<HTMLCanvasElement>
+  canvas: MaybeRef<HTMLCanvasElement | undefined>
   windowSize: MaybeRefOrGetter<boolean>
   disableRender: MaybeRefOrGetter<boolean>
   rendererOptions: UseRendererOptions
 }): TresContext {
 
-  const elementSize = computed(() =>
-    toValue(windowSize)
-      ? useWindowSize()
-      : useElementSize(toValue(canvas).parentElement)
+  const { logWarning } = useLogger()
+
+  const elementSize = computed(() => {
+    if (toValue(windowSize))
+      return useWindowSize()
+    if (!toValue(canvas)) logWarning('//TODO')
+    return useElementSize(toValue(canvas)!.parentElement)
+  }
   )
 
   const width = computed(() => elementSize.value.width.value)

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -15,7 +15,7 @@ export type TresContext = {
   raycaster: ShallowRef<Raycaster>
   controls: Ref<(EventDispatcher & { enabled: boolean }) | null>
   extend: (objects: any) => void
-  addCamera: (camera: Camera) => void;
+  addCamera: (camera: Camera, active?: boolean) => void;
   removeCamera: (camera: Camera) => void
   setCameraActive: (cameraOrUuid: Camera | string) => void;
 

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -1,12 +1,11 @@
 import { toValue, useElementSize, useWindowSize } from '@vueuse/core';
-import { inject, provide, readonly, shallowRef, computed, ref } from 'vue';
-import { useCamera } from '../useCamera';
 import { Camera, EventDispatcher, Raycaster, Scene, WebGLRenderer } from 'three';
-import { UseRendererOptions, useRenderer } from '../useRenderer';
+import { computed, inject, provide, readonly, ref, shallowRef } from 'vue';
 import { extend } from '../../core/catalogue';
+import { useCamera } from '../useCamera';
+import { UseRendererOptions, useRenderer } from '../useRenderer';
 
 import type { ComputedRef, DeepReadonly, MaybeRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue';
-import { useLogger } from '../useLogger';
 
 export type TresContext = {
   scene: ShallowRef<Scene>;
@@ -37,12 +36,9 @@ export function useTresContextProvider({
   rendererOptions: UseRendererOptions
 }): TresContext {
 
-  const { logWarning } = useLogger()
-
   const elementSize = computed(() => {
     if (toValue(windowSize))
       return useWindowSize()
-    if (!toValue(canvas)) logWarning('//TODO')
     return useElementSize(toValue(canvas)!.parentElement)
   }
   )

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -36,12 +36,7 @@ export function useTresContextProvider({
   rendererOptions: UseRendererOptions
 }): TresContext {
 
-  const elementSize = computed(() => {
-    if (toValue(windowSize))
-      return useWindowSize()
-    return useElementSize(toValue(canvas)!.parentElement)
-  }
-  )
+  const elementSize = computed(() => toValue(windowSize) ? useWindowSize() : useElementSize(toValue(canvas)?.parentElement))
 
   const width = computed(() => elementSize.value.width.value)
   const height = computed(() => elementSize.value.height.value)

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -29,7 +29,7 @@ export function useTresContextProvider({
   disableRender,
   rendererOptions
 }: {
-  scene: Scene,
+  scene: ShallowRef<Scene>,
   canvas: MaybeRef<HTMLCanvasElement | undefined>
   windowSize: MaybeRefOrGetter<boolean>
   disableRender: MaybeRefOrGetter<boolean>
@@ -53,7 +53,7 @@ export function useTresContextProvider({
     width,
     aspectRatio
   }
-  const localScene = shallowRef<Scene>(scene);
+
   const {
     camera,
     cameras,
@@ -73,7 +73,7 @@ export function useTresContextProvider({
 
   const toProvide: TresContext = {
     sizes,
-    scene: localScene,
+    scene,
     camera,
     cameras: readonly(cameras),
     renderer,

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -36,7 +36,11 @@ export function useTresContextProvider({
   rendererOptions: UseRendererOptions
 }): TresContext {
 
-  const elementSize = computed(() => toValue(windowSize) ? useWindowSize() : useElementSize(toValue(canvas)?.parentElement))
+  const elementSize = computed(() =>
+    toValue(windowSize)
+      ? useWindowSize()
+      : useElementSize(toValue(canvas)?.parentElement)
+  )
 
   const width = computed(() => elementSize.value.width.value)
   const height = computed(() => elementSize.value.height.value)

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,20 +1,12 @@
 import * as THREE from 'three'
 
-import { createRenderer, Slots } from 'vue'
+import { createRenderer } from 'vue'
 import { extend } from './catalogue'
 import { nodeOps } from './nodeOps'
 
-export const { createApp } = createRenderer(nodeOps)
-
-export const createTres = (slots: Slots) => {
-  const app = createApp(internalFnComponent)
-  function internalFnComponent() {
-    return slots && slots.default ? slots.default() : []
-  }
-  return app
-}
+export const { render } = createRenderer(nodeOps)
 
 // Creates the catalogue of components based on THREE namespace
 extend(THREE)
 
-export default { createTres, extend }
+export default { extend, render }


### PR DESCRIPTION
just use the render function instead of creating a Vue app instance just work

avoid vue devtools crash
![image](https://github.com/Tresjs/tres/assets/29378026/7a941200-465b-4648-85b7-038802436382)

***

I also have an idea about Vue devtools, how about creating a plugin with TresJS to improve DX of that?

I have taken a little time to check the Vue devtools doc, it seems we can display something in THREE scenes like object list, camera objects, and light objects. etc. just like Vue Router did