### PR TITLE
chore: add package.json -> exports.require = "./dist/tres.umd.cjs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/tres.js"
+      "import": "./dist/tres.js",
+      "require": "./dist/tres.umd.cjs"
     },
     "./components": {
       "types": "./dist/components/index.d.ts"


### PR DESCRIPTION
In other project ecosystems, there may be compile-time reference errors.

` vite.config.ts `
import { templateCompilerOptions } from '@tresjs/core' 

so this part is added