### PR TITLE
fix(types): 427 vueprops change ref to vnoderef and key add nu…

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import type { DefineComponent, Ref, VNode } from 'vue'
+import type { DefineComponent, VNode, VNodeRef } from 'vue'
 
 import type * as THREE from 'three'
 import type { EventProps as PointerEventHandlerEventProps } from '../composables/usePointerEventHandler'
@@ -160,8 +160,8 @@ type EventProps<P> = P extends RaycastableRepresentation ? Partial<EventHandlers
 
 export interface VueProps<P> {
   children?: VNode[]
-  ref?: string | null | Ref<P>
-  key?: string
+  ref?: VNodeRef
+  key?: string | number | symbol
 }
 
 type ElementProps<T extends ConstructorRepresentation, P = InstanceType<T>> = Partial<


### PR DESCRIPTION
types (fix #427)

Updated `ref` in VueProps to use `VNodeRef` type from vue, to support using a [function ref](https://vuejs.org/guide/essentials/template-refs.html#function-refs). Also updated key to accept numbers and symbols

https://github.com/Tresjs/tres/issues/427