### PR TITLE
feat: 140 on demand rendering

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
         items: [
           { text: 'Extending', link: '/advanced/extending' },
           { text: 'primitive', link: '/advanced/primitive' },
+          { text: 'Performance', link: '/advanced/performance' },
           {
             text: 'Caveats',
             link: '/advanced/caveats',

--- a/docs/.vitepress/theme/components/BlenderCube.vue
+++ b/docs/.vitepress/theme/components/BlenderCube.vue
@@ -2,7 +2,8 @@
 import { useTresContext } from '@tresjs/core'
 import { useGLTF } from '@tresjs/cientos'
 
-const { nodes } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/blender-cube.glb', { draco: true })
+const { nodes } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/blender-cube.glb', 
+  { draco: true })
 const model = nodes.Cube
 
 model.position.set(0, 1, 0)

--- a/docs/.vitepress/theme/components/BlenderCube.vue
+++ b/docs/.vitepress/theme/components/BlenderCube.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useTresContext } from '@tresjs/core'
+import { useGLTF } from '@tresjs/cientos'
+
+const { nodes } = await useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/blender-cube.glb', { draco: true })
+const model = nodes.Cube
+
+model.position.set(0, 1, 0)
+
+const state = useTresContext()
+
+state.invalidate()
+</script>
+
+<template>
+  <primitive :object="model" />
+</template>

--- a/docs/.vitepress/theme/components/GraphPane.vue
+++ b/docs/.vitepress/theme/components/GraphPane.vue
@@ -1,0 +1,87 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { useRafFn } from '@vueuse/core'
+import { useState } from '../composables/state'
+
+const width = 160
+const height = 40
+const strokeWidth = 2
+const updateInterval = 100 // Update interval in milliseconds
+const topOffset = 0 // Offset from the top
+
+const points = ref('')
+const frameTimes = ref([])
+const maxFrames = ref(width / strokeWidth)
+
+let lastUpdateTime = performance.now()
+
+const { renderingTimes } = useState()
+
+useRafFn(({ timestamp }) => {
+  if (timestamp - lastUpdateTime >= updateInterval) {
+    lastUpdateTime = timestamp
+
+    frameTimes.value.push(renderingTimes?.value)
+    renderingTimes.value = 0
+
+    if (frameTimes.value.length > maxFrames.value) {
+      frameTimes.value.shift()
+    }
+
+    points.value = frameTimes.value
+      .map(
+        (value, index) =>
+          `${index * strokeWidth},${
+            height + topOffset - strokeWidth / 2 - (value * (height + topOffset - strokeWidth)) / 2
+          }`,
+      )
+      .join(' ')
+  }
+})
+</script>
+
+<template>
+  <div
+    class="absolute right-2 top-2 flex px-4 py-1 justify-between gap-4 items-center mb-2 z-10 bg-white shadow-xl
+      rounded 
+      border-4 
+      border-solid 
+      bg-primary 
+      border-primary 
+      pointer-events-none
+      overflow-hidden"
+  >
+    <label class="text-secondary text-xs w-1/3">Rendering Activity</label>
+
+    <div
+      class="
+        bg-gray-100
+        relative
+        w-2/3
+        p-1
+        rounded
+        text-right
+        text-xs
+        focus:border-gray-200
+        outline-none
+        border-none
+        font-sans
+      "
+    >
+      <svg
+        :width="width"
+        :height="height"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+      >
+        <polyline
+          :points="points"
+          stroke="lightgray"
+          :stroke-width="strokeWidth"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/GraphPane.vue
+++ b/docs/.vitepress/theme/components/GraphPane.vue
@@ -42,7 +42,20 @@ useRafFn(({ timestamp }) => {
 
 <template>
   <div
-    class="absolute right-2 top-2 flex px-4 py-1 justify-between gap-4 items-center mb-2 z-10 bg-white shadow-xl
+    class="absolute
+      right-2
+      top-2
+      flex
+      px-4
+      py-1
+      justify-between
+      gap-4
+      items-center
+      mb-2
+      z-10
+      bg-white
+      dark:bg-dark
+      shadow-xl
       rounded 
       border-4 
       border-solid 
@@ -56,6 +69,7 @@ useRafFn(({ timestamp }) => {
     <div
       class="
         bg-gray-100
+        dark:bg-gray-600
         relative
         w-2/3
         p-1

--- a/docs/.vitepress/theme/components/OnDemandRendering.vue
+++ b/docs/.vitepress/theme/components/OnDemandRendering.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
+import { OrbitControls } from '@tresjs/cientos'
+import { useState } from '../composables/state'
+import BlenderCube from './BlenderCube.vue'
+import GraphPane from './GraphPane.vue'
+import RenderingLogger from './RenderingLogger.vue'
+
+const { renderingTimes } = useState()
+
+function onRender() {
+  renderingTimes.value = 1
+
+}
+</script>
+
+<template>
+  <GraphPane />
+  <TresCanvas
+    render-mode="on-demand"
+    clear-color="#82DBC5"
+    @render="onRender"
+  >
+    <TresPerspectiveCamera
+      :position="[5, 5, 5]"
+      :look-at="[0, 0, 0]"
+    />
+    <Suspense>
+      <BlenderCube />
+    </Suspense>
+    <TresGridHelper />
+    <RenderingLogger />
+    <TresAmbientLight :intensity="1" />
+    <TresDirectionalLight
+      :position="[0, 8, 4]"
+      :intensity="0.7"
+    />
+  </TresCanvas>
+</template>

--- a/docs/.vitepress/theme/components/RenderingLogger.vue
+++ b/docs/.vitepress/theme/components/RenderingLogger.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { useRenderLoop, useTresContext } from '@tresjs/core'
+import { OrbitControls } from '@tresjs/cientos'
+import { onMounted } from 'vue'
+import { useState } from '../composables/state'
+
+const { renderingTimes } = useState()
+
+const state = useTresContext()
+
+function manualInvalidate() {
+  state.invalidate()
+}
+
+onMounted(() => {
+  manualInvalidate()
+})
+</script>
+
+<template>
+  <OrbitControls
+    @change="manualInvalidate"
+  />
+</template>

--- a/docs/.vitepress/theme/composables/state.ts
+++ b/docs/.vitepress/theme/composables/state.ts
@@ -1,0 +1,11 @@
+import { reactive, toRefs } from 'vue'
+
+const state = reactive({
+  renderingTimes: 0,
+})
+export function useState() {
+  return {
+    ...toRefs(state),
+    
+  }
+}

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -32,9 +32,9 @@ You can do that by setting the `renderMode` prop to `on-demand` or `manual`:
 
 #### Automatic Invalidation
 
-When using `render-mode="on-demand"`, Tres.js will automatically invalidate the current frame by observing component props and lyfecycle hooks like `onMounted` and `onUnmounted`. It will also invalidate the frame when resizing the window or change any prop from the `<TresCanvas>` component like `clearColor` or `antialias`.
+When using `render-mode="on-demand"`, Tres.js will automatically invalidate the current frame by observing component props and lifecycle hooks like `onMounted` and `onUnmounted`. It will also invalidate the frame when resizing the window or changing any prop from the `<TresCanvas>` component like `clearColor` or `antialias`.
 
-This will trigger a new render: 
+The code below updates TresMesh's position-x prop every second, triggering a new render.
 
 ```vue
 <script setup>
@@ -59,7 +59,7 @@ setTimeout(() => {
 
 #### Manual Invalidation
 
-Since is not really possible to observe all the possible changes in your application, you can also manually invalidate the frame by calling the `invalidate()` method from the [`useTresContext` composable](../api/composables.md#usetrescontext):
+Since it is not really possible to observe all the possible changes in your application, you can also manually invalidate the frame by calling the `invalidate()` method from the [`useTresContext` composable](../api/composables.md#usetrescontext):
 
 
 ::: code-group

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -4,7 +4,7 @@
 
 We are running WebGL on the browser, which can be quite expensive and it will depend on how powerful the user's device is. To make 3D accessible to everyone, we need to make sure our applications are optimized to run also on low-end devices. This guide will provide some tips to improve the performance of your Tres.js application.
 
-## On-demand rendering
+## On-demand rendering <Badge type="tip" text="^4.0.0" />
 
 By default, Tres.js will render your scene on every frame. This is great for most applications, but if you are building a game or a complex application, you might want to control when the scene is rendered. 
 

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -1,0 +1,34 @@
+# Scaling performance 🚀
+
+> Quick guide with tips to improve performance of your Tres.js application.
+
+We are running WebGL on the browser, which can be quite expensive and it will depend on how powerful the user's device is. To make 3D accessible to everyone, we need to make sure our applications are optimized to run also on low-end devices. This guide will provide some tips to improve the performance of your Tres.js application.
+
+## On-demand rendering
+
+By default, Tres.js will render your scene on every frame. This is great for most applications, but if you are building a game or a complex application, you might want to control when the scene is rendered. 
+
+Otherwise it might drain your device battery 🔋 🔜 🪫 and make your computer sound like an airplane 🛫.
+
+Ideally, you only want to **render the scene when necessary**, for example when the user interacts with the scene and the camera moves, or when objects in the scene are animated.
+
+You can do that by setting the `renderMode` prop to `on-demand` or `manual`:
+
+
+### Mode `on-demand`
+
+<ClientOnly>
+  <div style="position: relative; aspect-ratio: 16/9; height: auto; margin: 2rem 0; border-radius: 8px; overflow:hidden;">
+    <onDemandRendering />
+  </div>
+</ClientOnly>
+
+
+```vue
+<TresCanvas render-mode="on-demand">
+  <!-- Your scene goes here -->
+</TresCanvas>
+```
+
+
+

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -30,5 +30,102 @@ You can do that by setting the `renderMode` prop to `on-demand` or `manual`:
 </TresCanvas>
 ```
 
+#### Automatic Invalidation
 
+When using `render-mode="on-demand"`, Tres.js will automatically invalidate the current frame by observing component props and lyfecycle hooks like `onMounted` and `onUnmounted`. It will also invalidate the frame when resizing the window or change any prop from the `<TresCanvas>` component like `clearColor` or `antialias`.
+
+This will trigger a new render: 
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const positionX = ref(0)
+
+setTimeout(() => {
+  positionX.value = 1
+}, 1000)
+</script>
+
+<template>
+  <TresCanvas render-mode="on-demand">
+    <TresMesh :position-x="positionX">
+      <TresBoxGeometry />
+      <TresMeshBasicMaterial color="teal" />
+    </TresMesh>
+  </TresCanvas>
+</template>
+```
+
+#### Manual Invalidation
+
+Since is not really possible to observe all the possible changes in your application, you can also manually invalidate the frame by calling the `invalidate()` method from the [`useTresContext` composable](../api/composables.md#usetrescontext):
+
+
+::: code-group
+
+```vue [App.vue]
+<script setup>
+import { TresCanvas } from '@tresjs/core'
+import Scene from './Scene.vue'
+</script>
+
+<template>
+  <TresCanvas
+    render-mode="manual"
+  >
+    <Scene />
+  </TresCanvas>
+</template>
+```
+
+```vue [Scene.vue]
+<script setup>
+import { useTres } from '@tresjs/core'
+
+const boxRef = ref()
+const { invalidate } = useTres()
+
+watch(boxRef.value, () => {
+  boxRef.value.position.x = 1
+  invalidate()
+})
+</script>
+
+<template>
+  <TresMesh ref="boxRef">
+    <TresBoxGeometry />
+    <TresMeshBasicMaterial color="teal" />
+  </TresMesh>
+</template>
+```
+
+:::
+
+### Mode `always` 
+
+In this rendering mode, Tres will continously render the scene on every frame. This is the default mode and the easiest to use, but it's also the most resource expensive one.
+
+
+### Mode `manual`
+
+If you want to have full control of when the scene is rendered, you can set the `render-mode` prop to `manual`:
+
+```vue
+<TresCanvas render-mode="manual">
+  <!-- Your scene goes here -->
+</TresCanvas>
+```
+
+In this mode, Tres will not render the scene automatically. You will need to call the `advance()` method from the [`useTresContext` composable](../api/composables.md#usetrescontext) to render the scene:
+
+```vue
+<script setup>
+import { useTres } from '@tresjs/core'
+
+const { advance } = useTres()
+
+advance()
+</script>
+```
 

--- a/docs/api/composables.md
+++ b/docs/api/composables.md
@@ -233,4 +233,7 @@ const context = useTresContext()
 | **scene** | the [scene](https://threejs.org/docs/?q=sce#api/en/scenes/Scene). |
 | **setCameraActive** | a method to set a camera active |
 | **sizes** | contains width, height and aspect ratio of your canvas |
+| **invalidate** | a method to invalidate the render loop. This is only required if you set the `render-mode` prop to `on-demand`. |
+| **advance** | a method to advance the render loop. This is only required if you set the `render-mode` prop to `manual`. |
+
 

--- a/docs/api/tres-canvas.md
+++ b/docs/api/tres-canvas.md
@@ -77,12 +77,13 @@ renderer.shadowMap.type = PCFSoftShadowMap
 | **clearColor** | The color the renderer will use to clear the canvas. | `#000000` |
 | **context** | This can be used to attach the renderer to an existing [RenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext) | |
 | **depth** | Whether the drawing buffer has a [depth buffer](https://en.wikipedia.org/wiki/Z-buffering) of at least 16 bits. | `true` |
+| **renderMode** | Render mode, can be `always`, `on-demand` or `manual`. See [Performance](../advanced/performance)  | `always` |
 | **disableRender** | Disable render on requestAnimationFrame, useful for PostProcessing | `false` |
 | **failIfMajorPerformanceCaveat** | Whether the renderer creation will fail upon low performance is detected. See [WebGL spec](https://registry.khronos.org/webgl/specs/latest/1.0/#5.2) for details. | `false` |
 | **logarithmicDepthBuffer** | Whether to use a logarithmic depth buffer. It may be necessary to use this if dealing with huge differences in scale in a single scene. Note that this setting uses gl_FragDepth if available which disables the [Early Fragment Test](https://www.khronos.org/opengl/wiki/Early_Fragment_Test) optimization and can cause a decrease in performance. | `false` |
 | **outputColorSpace** | Defines the output encoding | `LinearEncoding` |
-| **powerPreference** | Provides a hint to the user agent indicating what configuration of GPU is suitable for this WebGL context. Can be "high-performance", "low-power" or "default". | `default` |
-| **precision** | Shader precision. Can be "highp", "mediump" or "lowp". | "highp" if supported by the device |
+| **powerPreference** | Provides a hint to the user agent indicating what configuration of GPU is suitable for this WebGL context. Can be `high-performance`, `low-power` or `default`. | `default` |
+| **precision** | Shader precision. Can be `highp`, `mediump` or `lowp`. | "highp" if supported by the device |
 | **premultipliedAlpha** | Whether the renderer will assume that colors have [premultiplied alpha](https://en.wikipedia.org/wiki/Glossary_of_computer_graphics#premultiplied_alpha). | `true` |
 | **preserveDrawingBuffer** | Whether to preserve the buffers until manually cleared or overwritten.. | `false` |
 | **shadows** | Enable shadows in the renderer | `false` |

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -7,14 +7,18 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
+    BlenderCube: typeof import('./.vitepress/theme/components/BlenderCube.vue')['default']
     DonutExample: typeof import('./.vitepress/theme/components/DonutExample.vue')['default']
     EmbedExperiment: typeof import('./.vitepress/theme/components/EmbedExperiment.vue')['default']
     ExtendExample: typeof import('./.vitepress/theme/components/ExtendExample.vue')['default']
     FirstScene: typeof import('./.vitepress/theme/components/FirstScene.vue')['default']
     FirstSceneLightToon: typeof import('./.vitepress/theme/components/FirstSceneLightToon.vue')['default']
+    GraphPane: typeof import('./.vitepress/theme/components/GraphPane.vue')['default']
     HomeSponsors: typeof import('./.vitepress/theme/components/HomeSponsors.vue')['default']
     LocalOrbitControls: typeof import('./.vitepress/theme/components/LocalOrbitControls.vue')['default']
     LoveVueThreeJS: typeof import('./.vitepress/theme/components/LoveVueThreeJS.vue')['default']
+    OnDemandRendering: typeof import('./.vitepress/theme/components/OnDemandRendering.vue')['default']
+    RenderingLogger: typeof import('./.vitepress/theme/components/RenderingLogger.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SandboxDemo: typeof import('./.vitepress/theme/components/SandboxDemo.vue')['default']

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "preview": "vitepress preview"
   },
   "dependencies": {
-    "@tresjs/core": "workspace:*"
+    "@tresjs/core": "workspace:^"
   },
   "devDependencies": {
     "unocss": "^0.58.3",

--- a/playground/src/pages/rendering-modes/index.vue
+++ b/playground/src/pages/rendering-modes/index.vue
@@ -13,7 +13,7 @@ setTimeout(() => {
 <template>
   <TresCanvas
     :clear-color="clearColor"
-    render-mode="manual"
+    render-mode="on-demand"
     @render="() => console.log('onRender')"
   >
     <Scene />

--- a/playground/src/pages/rendering-modes/index.vue
+++ b/playground/src/pages/rendering-modes/index.vue
@@ -13,7 +13,7 @@ setTimeout(() => {
 <template>
   <TresCanvas
     :clear-color="clearColor"
-    render-mode="on-demand"
+    render-mode="manual"
     @render="() => console.log('onRender')"
   >
     <Scene />

--- a/playground/src/pages/rendering-modes/index.vue
+++ b/playground/src/pages/rendering-modes/index.vue
@@ -2,11 +2,13 @@
 import { TresCanvas } from '@tresjs/core'
 
 import Scene from './scene.vue'
+
+const clearColor = ref('#82DBC5')
 </script>
 
 <template>
   <TresCanvas
-    clear-color="#82DBC5"
+    :clear-color="clearColor"
     render-mode="on-demand"
   >
     <Scene />

--- a/playground/src/pages/rendering-modes/index.vue
+++ b/playground/src/pages/rendering-modes/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+
+import Scene from './scene.vue'
+</script>
+
+<template>
+  <TresCanvas
+    clear-color="#82DBC5"
+    render-mode="on-demand"
+  >
+    <Scene />
+  </TresCanvas>
+</template>

--- a/playground/src/pages/rendering-modes/index.vue
+++ b/playground/src/pages/rendering-modes/index.vue
@@ -4,12 +4,17 @@ import { TresCanvas } from '@tresjs/core'
 import Scene from './scene.vue'
 
 const clearColor = ref('#82DBC5')
+
+setTimeout(() => {
+  clearColor.value = '#000000'
+}, 3000)
 </script>
 
 <template>
   <TresCanvas
     :clear-color="clearColor"
     render-mode="on-demand"
+    @render="() => console.log('onRender')"
   >
     <Scene />
   </TresCanvas>

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -8,13 +8,19 @@ function onControlChange() {
   invalidate()
 }
 
+const positionX = ref(0)
+
+setTimeout(() => {
+  positionX.value = 1
+}, 3000)
+
 invalidate()
 </script>
 
 <template>
   <OrbitControls @change="onControlChange" />
   <TresGridHelper />
-  <TresMesh>
+  <TresMesh :position-x="positionX">
     <TresBoxGeometry />
     <TresMeshNormalMaterial />
   </TresMesh>

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -5,7 +5,7 @@ import { OrbitControls } from '@tresjs/cientos'
 const { invalidate, advance } = useTres()
 
 function onControlChange() {
-  advance()
+  invalidate()
 }
 
 const positionX = ref(0)

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { useRenderLoop, useTres } from '@tresjs/core'
+import { OrbitControls } from '@tresjs/cientos'
+
+const { invalidate } = useTres()
+
+function onControlChange() {
+  invalidate()
+}
+
+invalidate()
+</script>
+
+<template>
+  <OrbitControls @change="onControlChange" />
+  <TresGridHelper />
+  <TresMesh>
+    <TresBoxGeometry />
+    <TresMeshNormalMaterial />
+  </TresMesh>
+  <TresAmbientLight :intensity="1" />
+</template>

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -13,7 +13,7 @@ const showMesh = ref(true)
 
 setTimeout(() => {
   /*  positionX.value = 1 */
-  showMesh.value = false
+/*   showMesh.value = false */
 }, 3000)
 
 /* invalidate() */

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -9,18 +9,23 @@ function onControlChange() {
 }
 
 const positionX = ref(0)
+const showMesh = ref(true)
 
 setTimeout(() => {
-  positionX.value = 1
+  /*  positionX.value = 1 */
+  showMesh.value = false
 }, 3000)
 
-invalidate()
+/* invalidate() */
 </script>
 
 <template>
   <OrbitControls @change="onControlChange" />
   <TresGridHelper />
-  <TresMesh :position-x="positionX">
+  <TresMesh
+    v-if="showMesh"
+    :position-x="positionX"
+  >
     <TresBoxGeometry />
     <TresMeshNormalMaterial />
   </TresMesh>

--- a/playground/src/pages/rendering-modes/scene.vue
+++ b/playground/src/pages/rendering-modes/scene.vue
@@ -2,21 +2,20 @@
 import { useRenderLoop, useTres } from '@tresjs/core'
 import { OrbitControls } from '@tresjs/cientos'
 
-const { invalidate } = useTres()
+const { invalidate, advance } = useTres()
 
 function onControlChange() {
-  invalidate()
+  advance()
 }
 
 const positionX = ref(0)
 const showMesh = ref(true)
 
 setTimeout(() => {
-  /*  positionX.value = 1 */
-/*   showMesh.value = false */
-}, 3000)
+  positionX.value = 1
+  /*   showMesh.value = false */
 
-/* invalidate() */
+}, 3000)
 </script>
 
 <template>

--- a/playground/src/router.ts
+++ b/playground/src/router.ts
@@ -77,6 +77,11 @@ const routes = [
     component: () => import('./pages/perf/index.vue'),
   },
   {
+    path: '/rendering-modes',
+    name: 'Rendering Modes',
+    component: () => import('./pages/rendering-modes/index.vue'),
+  },
+  {
     path: '/empty',
     name: 'empty',
     component: () => import('./pages/empty.vue'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
   docs:
     dependencies:
       '@tresjs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:..
     devDependencies:
       unocss:

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -45,7 +45,7 @@ export interface TresCanvasProps
   useLegacyLights?: boolean
   outputColorSpace?: ColorSpace
   toneMappingExposure?: number
-  renderMode?: 'always' | 'on-demand' 
+  renderMode?: 'always' | 'on-demand' | 'manual' 
 
   // required by useTresContextProvider
   camera?: TresCamera

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -45,6 +45,7 @@ export interface TresCanvasProps
   useLegacyLights?: boolean
   outputColorSpace?: ColorSpace
   toneMappingExposure?: number
+  renderMode?: 'always' | 'on-demand' 
 
   // required by useTresContextProvider
   camera?: TresCamera
@@ -65,6 +66,7 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
   preserveDrawingBuffer: undefined,
   logarithmicDepthBuffer: undefined,
   failIfMajorPerformanceCaveat: undefined,
+  renderMode: 'always',
 })
 
 const { logWarning } = useLogger()
@@ -129,8 +131,8 @@ onMounted(() => {
   context.value = useTresContextProvider({
     scene: scene.value,
     canvas: existingCanvas,
-    windowSize: props.windowSize,
-    disableRender,
+    windowSize: props.windowSize ?? true,
+    disableRender: disableRender.value ?? false,
     rendererOptions: props,
   })
 

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -69,6 +69,8 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
   renderMode: 'always',
 })
 
+const emit = defineEmits(['render'])
+
 const { logWarning } = useLogger()
 
 const canvas = ref<HTMLCanvasElement>()
@@ -124,7 +126,6 @@ const disableRender = computed(() => props.disableRender)
 const context = shallowRef<TresContext | null>(null)
 
 defineExpose({ context, dispose: () => dispose(context.value as TresContext, true) })
-
 onMounted(() => {
   const existingCanvas = canvas as Ref<HTMLCanvasElement>
 
@@ -134,6 +135,7 @@ onMounted(() => {
     windowSize: props.windowSize ?? true,
     disableRender: disableRender.value ?? false,
     rendererOptions: props,
+    emit,
   })
 
   usePointerEventHandler({ scene: scene.value, contextParts: context.value })

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -132,7 +132,7 @@ onMounted(() => {
   context.value = useTresContextProvider({
     scene: scene.value,
     canvas: existingCanvas,
-    windowSize: props.windowSize ?? true,
+    windowSize: props.windowSize ?? false,
     disableRender: disableRender.value ?? false,
     rendererOptions: props,
     emit,

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -111,13 +111,14 @@ export function useRenderer(
     options,
     disableRender,
     emit,
-    contextParts: { sizes, camera, internal, invalidate },
+    contextParts: { sizes, camera, internal, invalidate, advance },
   }:
   {
     canvas: MaybeRef<HTMLCanvasElement>
     scene: Scene
     options: UseRendererOptions
-    contextParts: Pick<TresContext, 'sizes' | 'camera'>
+    emit: (event: string, ...args: any[]) => void
+    contextParts: Pick<TresContext, 'sizes' | 'camera' | 'internal'> & { invalidate: () => void; advance: () => void }
     disableRender: MaybeRefOrGetter<boolean>
   },
 ) {
@@ -185,7 +186,11 @@ export function useRenderer(
     // Reset priority
     internal.priority.value = 0
 
-    internal.frames.value = Math.max(0, internal.frames.value - 1)
+    // If renderMode is not 'manual', auto-decrement frames
+    // If it is 'manual', frames will be managed by the advance function
+    if (renderMode !== 'manual') {
+      internal.frames.value = Math.max(0, internal.frames.value - 1)
+    }
 
     if (toValue(options.renderMode) === 'always') {
       internal.frames.value = 1

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -96,7 +96,7 @@ export interface UseRendererOptions extends TransformToMaybeRefOrGetter<WebGLRen
   clearColor?: MaybeRefOrGetter<TresColor>
   windowSize?: MaybeRefOrGetter<boolean | string>
   preset?: MaybeRefOrGetter<RendererPresetsType>
-  renderMode?: MaybeRefOrGetter<'always' | 'on-demand'>
+  renderMode?: MaybeRefOrGetter<'always' | 'on-demand' | 'manual'>
 }
 
 /**

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -168,9 +168,6 @@ export function useRenderer(
     if (camera.value && !toValue(disableRender) && internal.frames.value > 0)
       renderer.value.render(scene, camera.value)
 
-    // Call subscribers' render callbacks
-    internal.subscribers.value.forEach(({ callback }) => callback())
-
     // Reset priority
     internal.priority.value = 0
 

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -111,14 +111,14 @@ export function useRenderer(
     options,
     disableRender,
     emit,
-    contextParts: { sizes, camera, internal, invalidate, advance },
+    contextParts: { sizes, camera, render, invalidate, advance },
   }:
   {
     canvas: MaybeRef<HTMLCanvasElement>
     scene: Scene
     options: UseRendererOptions
     emit: (event: string, ...args: any[]) => void
-    contextParts: Pick<TresContext, 'sizes' | 'camera' | 'internal'> & { invalidate: () => void; advance: () => void }
+    contextParts: Pick<TresContext, 'sizes' | 'camera' | 'render'> & { invalidate: () => void; advance: () => void }
     disableRender: MaybeRefOrGetter<boolean>
   },
 ) {
@@ -178,19 +178,19 @@ export function useRenderer(
   const { resume, onLoop } = useRenderLoop()
 
   onLoop(() => {
-    if (camera.value && !toValue(disableRender) && internal.frames.value > 0) {
+    if (camera.value && !toValue(disableRender) && render.frames.value > 0) {
       renderer.value.render(scene, camera.value)
       emit('render', renderer.value)
     }
 
     // Reset priority
-    internal.priority.value = 0
+    render.priority.value = 0
 
     if (toValue(options.renderMode) === 'always') {
-      internal.frames.value = 1
+      render.frames.value = 1
     }
     else {
-      internal.frames.value = Math.max(0, internal.frames.value - 1)
+      render.frames.value = Math.max(0, render.frames.value - 1)
     }
 
   })
@@ -245,7 +245,7 @@ export function useRenderer(
 
     if (renderMode === 'always') {
       // If the render mode is 'always', ensure there's always a frame pending
-      internal.frames.value = Math.max(1, internal.frames.value)
+      render.frames.value = Math.max(1, render.frames.value)
     }
 
     const getValue = <T>(option: MaybeRefOrGetter<T>, pathInThree: string): T | undefined => {

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -111,7 +111,7 @@ export function useRenderer(
     canvas,
     options,
     disableRender,
-    contextParts: { sizes, camera, internal },
+    contextParts: { sizes, camera, internal, invalidate },
   }:
   {
     canvas: MaybeRef<HTMLCanvasElement>
@@ -218,7 +218,11 @@ export function useRenderer(
     if (renderMode === 'always') {
       // If the render mode is 'always', ensure there's always a frame pending
       internal.frames.value = Math.max(1, internal.frames.value)
-    } 
+    }
+    else {
+      // Invalidate for the first time
+      invalidate()
+    }
 
     const getValue = <T>(option: MaybeRefOrGetter<T>, pathInThree: string): T | undefined => {
       const value = toValue(option)

--- a/src/composables/useRenderer/index.ts
+++ b/src/composables/useRenderer/index.ts
@@ -141,30 +141,32 @@ export function useRenderer(
 
   const renderer = shallowRef<WebGLRenderer>(new WebGLRenderer(webGLRendererConstructorParameters.value))
 
+  function invalidateOnDemand() {
+    if (options.renderMode === 'on-demand') {
+      invalidate()
+    }
+  }
   // since the properties set via the constructor can't be updated dynamically,
   // the renderer is recreated once they change
   watch(webGLRendererConstructorParameters, () => {
     renderer.value.dispose()
     renderer.value = new WebGLRenderer(webGLRendererConstructorParameters.value)
 
-    if (options.renderMode === 'on-demand') {
-      invalidate()
-    }
+    invalidateOnDemand()
   })
 
-  watchEffect(() => {
+  watch([sizes.width, sizes.height], () => {
     renderer.value.setSize(sizes.width.value, sizes.height.value)
+    invalidateOnDemand()
+  }, {
+    immediate: true,
   })
 
-  watch(() => options.clearColor, () => {
-    if (options.renderMode === 'on-demand') {
-      invalidate()
-    }
-  })
+  watch(() => options.clearColor, invalidateOnDemand)
 
   const { pixelRatio } = useDevicePixelRatio()
 
-  watchEffect(() => {
+  watch(pixelRatio, () => {
     renderer.value.setPixelRatio(pixelRatio.value)
   })
 

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -52,12 +52,14 @@ export function useTresContextProvider({
   windowSize,
   disableRender,
   rendererOptions,
+  emit,
 }: {
   scene: Scene
   canvas: MaybeRef<HTMLCanvasElement>
   windowSize: MaybeRefOrGetter<boolean>
   disableRender: MaybeRefOrGetter<boolean>
   rendererOptions: UseRendererOptions
+  emit: (event: string, ...args: any[]) => void
 }): TresContext {
 
   const elementSize = computed(() =>
@@ -97,6 +99,7 @@ export function useTresContextProvider({
       scene,
       canvas,
       options: rendererOptions,
+      emit,
       contextParts: { sizes, camera, internal, invalidate },
       disableRender,
     })

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -97,7 +97,7 @@ export function useTresContextProvider({
       scene,
       canvas,
       options: rendererOptions,
-      contextParts: { sizes, camera, internal },
+      contextParts: { sizes, camera, internal, invalidate },
       disableRender,
     })
 

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -8,6 +8,7 @@ import { useCamera } from '../useCamera'
 import type { UseRendererOptions } from '../useRenderer'
 import { useRenderer } from '../useRenderer'
 import { extend } from '../../core/catalogue'
+import { useLogger } from '../useLogger'
 
 export interface InternalState {
   priority: Ref<number>
@@ -74,6 +75,8 @@ export function useTresContextProvider({
   emit: (event: string, ...args: any[]) => void
 }): TresContext {
 
+  const { logWarning } = useLogger()
+
   const elementSize = computed(() =>
     toValue(windowSize)
       ? useWindowSize()
@@ -108,12 +111,20 @@ export function useTresContextProvider({
 
   function invalidate(frames = 1) {
     // Increase the frame count, ensuring not to exceed a maximum if desired
-    internal.frames.value = Math.min(internal.maxFrames, internal.frames.value + frames)
+    if (rendererOptions.renderMode === 'on-demand') {
+      internal.frames.value = Math.min(internal.maxFrames, internal.frames.value + frames)
+    }
+    else {
+      logWarning('`invalidate` can only be used when `renderMode` is set to `on-demand`')
+    }
   }
 
   function advance() {
     if (rendererOptions.renderMode === 'manual') {
-      invalidate()
+      internal.frames.value = 1
+    }
+    else {
+      logWarning('`advance` can only be used when `renderMode` is set to `manual`')
     }
   }
 

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -9,17 +9,10 @@ import type { UseRendererOptions } from '../useRenderer'
 import { useRenderer } from '../useRenderer'
 import { extend } from '../../core/catalogue'
 
-export interface InternalSubscriber {
-  callback: (timestamp: number) => void
-  priority: number
-}
-
 export interface InternalState {
   priority: Ref<number>
   frames: Ref<number>
-  subscribers: Ref<InternalSubscriber[]>
   maxFrames: number
-  subscribe: (callback: (timestamp: number) => void, priority: number) => () => void
 }
 
 export interface PerformanceState {
@@ -95,20 +88,7 @@ export function useTresContextProvider({
   const internal: InternalState = {
     priority: ref(0),
     frames: ref(0),
-    subscribers: ref([]),
     maxFrames: 60,
-    subscribe: (callback, priority) => {
-      const subscription = { callback, priority }
-      internal.subscribers.value.push(subscription)
-      // Sort subscribers based on priority
-      internal.subscribers.value.sort((a, b) => b.priority - a.priority)
-  
-      // Return an unsubscribe function
-      return () => {
-        const index = internal.subscribers.value.indexOf(subscription)
-        if (index > -1) internal.subscribers.value.splice(index, 1)
-      }
-    },
   }
 
   const { renderer } = useRenderer(

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -38,6 +38,7 @@ export interface TresContext {
   renderer: ShallowRef<WebGLRenderer>
   raycaster: ShallowRef<Raycaster>
   perf: PerformanceState
+  renderMode: MaybeRefOrGetter<'always' | 'on-demand' | 'manual'>
   internal: InternalState
   invalidate: () => void
   registerCamera: (camera: Camera) => void
@@ -125,6 +126,7 @@ export function useTresContextProvider({
         accumulator: [],
       },
     },
+    renderMode: ref(rendererOptions.renderMode || 'always'),
     internal,
     extend,
     invalidate,
@@ -134,6 +136,9 @@ export function useTresContextProvider({
   }
 
   provide('useTres', toProvide)
+
+  // Add context to scene.userData
+  toProvide.scene.value.userData.tres__context = toProvide
 
   // Performance
   const updateInterval = 100 // Update interval in milliseconds
@@ -182,7 +187,7 @@ export function useTresContextProvider({
   let accumulatedTime = 0
   const interval = 1 // Interval in milliseconds, e.g., 1000 ms = 1 second
     
-  const { pause, resume } = useRafFn(({ delta }) => {
+  const { pause } = useRafFn(({ delta }) => {
     if (!window.__TRES__DEVTOOLS__) return
 
     updatePerformanceData({ timestamp: performance.now() })

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -45,6 +45,7 @@ export interface TresContext {
    * If set to 'always', the scene will be rendered every frame
    */
   renderMode: Ref<'always' | 'on-demand' | 'manual'>
+  canBeInvalidated: ComputedRef<boolean>
   internal: InternalState
   /**
    * Invalidates the current frame when renderMode === 'on-demand'
@@ -147,6 +148,8 @@ export function useTresContextProvider({
       disableRender,
     })
 
+  const renderMode = ref<'always' | 'on-demand' | 'manual'>(rendererOptions.renderMode || 'always')
+
   const toProvide: TresContext = {
     sizes,
     scene: localScene,
@@ -167,7 +170,8 @@ export function useTresContextProvider({
         accumulator: [],
       },
     },
-    renderMode: ref(rendererOptions.renderMode || 'always'),
+    renderMode,
+    canBeInvalidated: computed(() => renderMode.value === 'on-demand' && internal.frames.value === 0),
     internal,
     advance,
     extend,

--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -28,7 +28,7 @@ export function invalidateInstance(instance: TresObject) {
   
   if (!ctx) return
   
-  if (ctx.renderMode.value === 'on-demand' && ctx.internal.frames.value === 0) {
+  if (ctx.canBeInvalidated.value) {
     ctx.invalidate()
   }
 

--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -28,7 +28,7 @@ export function invalidateInstance(instance: TresObject) {
   
   if (!ctx) return
   
-  if (ctx.canBeInvalidated.value) {
+  if (ctx.render && ctx.render.canBeInvalidated.value) {
     ctx.invalidate()
   }
 

--- a/src/devtools/plugin.ts
+++ b/src/devtools/plugin.ts
@@ -271,11 +271,14 @@ export function registerTresDevtools(app: DevtoolsApp, tres: TresContext) {
                 key: 'matrixWorld',
                 value: instance.matrixWorld,
               },
-                
               {
                 key: 'visible',
                 editable: true,
                 value: instance.visible,
+              },
+              {
+                key: 'userData',
+                value: instance.userData,
               },
             ],
           }


### PR DESCRIPTION
This PR introduces the concept of conditional rendering. It closes #140

The `renderMode` prop has been added to the `TresCanvas` component with 3 different options:

- `always` the default one (current solution)
- `on-demand` will automatically invalidate the frame on:
   - Instances prop changes
   - Context state change (resize, clearColor etc)
   - remove nodes (v-if)
- `manual`:  the `invalidate` method needs to be called by the user to trigger a render.

TresCanvas now emits a `render` event:

```
<TresCanvas
    render-mode="on-demand"
    clear-color="#82DBC5"
    @render="onRender"
  >
  ```

I'm still finishing the docs, you can start taking a look to it.
