### PR TITLE
refactor: Simplify the logic for calculating sizes and extract it into useSizes

### DIFF
--- a/src/composables/useSizes/index.ts
+++ b/src/composables/useSizes/index.ts
@@ -11,14 +11,14 @@ export interface SizesType {
 export default function useSizes(
   windowSize: MaybeRefOrGetter<boolean>,
   canvas: MaybeRef<HTMLCanvasElement>,
-  debounce: number = 10,
+  debounceMs: number = 10,
 ) {
   const reactiveSize = toValue(windowSize)
     ? useWindowSize()
     : useElementSize(computed(() => toValue(canvas).parentElement))
 
-  const debouncedReactiveWidth = readonly(refDebounced(reactiveSize.width, debounce))
-  const debouncedReactiveHeight = readonly(refDebounced(reactiveSize.height, debounce))
+  const debouncedReactiveWidth = readonly(refDebounced(reactiveSize.width, debounceMs))
+  const debouncedReactiveHeight = readonly(refDebounced(reactiveSize.height, debounceMs))
 
   const aspectRatio = computed(() => debouncedReactiveWidth.value / debouncedReactiveHeight.value)
 

--- a/src/composables/useSizes/index.ts
+++ b/src/composables/useSizes/index.ts
@@ -1,5 +1,5 @@
 import { computed, readonly } from 'vue'
-import type { MaybeRefOrGetter, MaybeRef } from 'vue'
+import type { MaybeRefOrGetter, MaybeRef, ComputedRef, Ref } from 'vue'
 import { refDebounced, toValue, useElementSize, useWindowSize } from '@vueuse/core'
 
 export interface SizesType {

--- a/src/composables/useSizes/index.ts
+++ b/src/composables/useSizes/index.ts
@@ -1,0 +1,30 @@
+import { computed, readonly } from 'vue'
+import type { MaybeRefOrGetter, MaybeRef } from 'vue'
+import { refDebounced, toValue, useElementSize, useWindowSize } from '@vueuse/core'
+
+export interface SizesType {
+  height: Readonly<Ref<number>>
+  width: Readonly<Ref<number>>
+  aspectRatio: ComputedRef<number>
+}
+
+export default function useSizes(
+  windowSize: MaybeRefOrGetter<boolean>,
+  canvas: MaybeRef<HTMLCanvasElement>,
+  debounce: number = 10,
+) {
+  const reactiveSize = toValue(windowSize)
+    ? useWindowSize()
+    : useElementSize(computed(() => toValue(canvas).parentElement))
+
+  const debouncedReactiveWidth = readonly(refDebounced(reactiveSize.width, debounce))
+  const debouncedReactiveHeight = readonly(refDebounced(reactiveSize.height, debounce))
+
+  const aspectRatio = computed(() => debouncedReactiveWidth.value / debouncedReactiveHeight.value)
+
+  return {
+    height: debouncedReactiveHeight,
+    width: debouncedReactiveWidth,
+    aspectRatio,
+  }
+}


### PR DESCRIPTION
Attempting to simplify the logic related to `sizes` and extract it into `useSizes` for easier maintenance in the future.