### PR TITLE
docs: change image path to silence warning, #518 

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -81,7 +81,7 @@ We have a brand new [StackBlitz](https://stackblitz.com/) starter to try TresJS 
 
 We also have a playground where you can try TresJS online. Check it out [here](https://playground.tresjs.org/).
 
-![](/public/playground.png)
+![](/playground.png)
 
 ## Motivation
 


### PR DESCRIPTION
Closes #518

## Problem

When running `pnpm run docs:dev` a warning was being printed to the terminal about an image path:

```
5:05:06 PM [vitepress] hmr update /guide/index.md
Assets in public directory cannot be imported from JavaScript.
If you intend to import that asset, put the file in the src directory, and use /src/playground.png instead of /public/playground.png.
If you intend to use the URL of that asset, use /playground.png?url.
Files in the public directory are served at the root path.
Instead of /public/playground.png, use /playground.png.
```
## Solution

This updates the image path to remove the warning.