### PR TITLE
chore(docs): Fix OrbitControls docs missing ".js" extension

### DIFF
--- a/docs/cookbook/orbit-controls.md
+++ b/docs/cookbook/orbit-controls.md
@@ -25,14 +25,14 @@ For more information about extending your TresJS catalog, refer to the [extendin
 To use `OrbitControls` you need to import it from the `three/addons/controls/OrbitControls` module.
 
 ```js
-import { OrbitControls } from 'three/addons/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 ```
 
 Then you need to extend the catalogue of components using the `extend` method.
 
 ```js
 import { extend } from '@tresjs/core'
-import { OrbitControls } from 'three/addons/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
 extend({ OrbitControls })
 ```
@@ -70,7 +70,7 @@ So the final code would be something like this:
 ```vue [OrbitControls.vue]
 <script setup lang="ts">
 import { extend, useTresContext } from '@tresjs/core'
-import { OrbitControls } from 'three/addons/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
 extend({ OrbitControls })
 


### PR DESCRIPTION
Added missing `.js` suffix for importing [OrbitControls](https://threejs.org/docs/#examples/en/controls/OrbitControls) from the `three` package (since it's not a TS file).

Before:
```js
import { OrbitControls } from 'three/addons/controls/OrbitControls
```

After:
```js
import { OrbitControls } from 'three/addons/controls/OrbitControls.js
```

I'm using this in a Nuxt project (`@tresjs/nuxt` package)—maybe I just need to configure my TS [Module Resolutions](https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution) or some other TS settings? Using the default Nuxt `tsconfig.json`:

```js
{
  "extends": "./.nuxt/tsconfig.json"
}
```

**Update 1**
Modifying the project-level `tsconfig.json` to the following enables `.js` files to resolve:
```js
{
  "extends": "./.nuxt/tsconfig.json",
  "compilerOptions": {
    "moduleResolution": "node",
    "baseUrl": ".",
    "paths": {
      "~/*": [
        "./*"
      ],
      "@/*": [
        "./*"
      ],
      "*": [
        "*",
        "*.ts",
        "*.js"
      ]
    },
  }
}
```