### PR TITLE
fix: make on* callbacks settable

### DIFF
--- a/playground/src/pages/basic/OnCallbacks.vue
+++ b/playground/src/pages/basic/OnCallbacks.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { Mesh, MeshBasicMaterial, SphereGeometry } from 'three'
+
+const geo = new SphereGeometry()
+const mat = new MeshBasicMaterial()
+const obj = new Mesh(geo, mat)
+
+const meshNumOnBeforeRenders = shallowRef(0)
+const meshNumOnAfterRenders = shallowRef(0)
+const primitiveNumOnBeforeRenders = shallowRef(0)
+const primitiveNumOnAfterRenders = shallowRef(0)
+const materialNumOnBeforeCompiles = shallowRef(0)
+
+const meshOnBeforeRender = () => { meshNumOnBeforeRenders.value++ }
+const meshOnAfterRender = () => { meshNumOnAfterRenders.value++ }
+const primitiveOnBeforeRender = () => { primitiveNumOnBeforeRenders.value++ }
+const primitiveOnAfterRender = () => { primitiveNumOnAfterRenders.value++ }
+const materialOnBeforeCompile = () => { materialNumOnBeforeCompiles.value++ }
+</script>
+
+<template>
+  <div class="overlay">
+    <h2>Primitive</h2>
+    <ul>
+      <li># onBeforeRender calls: {{ primitiveNumOnBeforeRenders }}</li>
+      <li># onAfterRender calls: {{ primitiveNumOnAfterRenders }}</li>
+    </ul>
+    <h2>Mesh</h2>
+    <ul>
+      <li># onBeforeRender calls: {{ meshNumOnBeforeRenders }}</li>
+      <li># onAfterRender calls: {{ meshNumOnAfterRenders }}</li>
+    </ul>
+    <h2>Material</h2>
+    <ul>
+      <li># onBeforeCompile calls: {{ materialNumOnBeforeCompiles }}</li>
+    </ul>
+  </div>
+  <TresCanvas>
+    <TresMesh
+      :position="[1, 0, 0]"
+      :scale="0.5"
+      :on-before-render="meshOnBeforeRender"
+      :on-after-render="meshOnAfterRender"
+    >
+      <TresBoxGeometry />
+      <TresMeshStandardMaterial
+        :on-before-compile="materialOnBeforeCompile"
+      />
+    </TresMesh>
+    <primitive
+      :object="obj"
+      :position="[-1, 0, 0]"
+      :scale="0.5"
+      :on-before-render="primitiveOnBeforeRender"
+      :on-after-render="primitiveOnAfterRender"
+    />
+    <TresGridHelper :args="[10, 10, 0x444444, 'teal']" />
+  </TresCanvas>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  z-index: 1;
+  font-family: sans-serif;
+  background-color: #fff;
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px;
+}
+</style>

--- a/playground/src/router/routes/basic.ts
+++ b/playground/src/router/routes/basic.ts
@@ -35,6 +35,11 @@ export const basicRoutes = [
     component: () => import('../../pages/basic/Responsiveness.vue'),
   },
   {
+    path: '/basic/onCallbacks',
+    name: 'on... callbacks',
+    component: () => import('../../pages/basic/OnCallbacks.vue'),
+  },
+  {
     path: '/basic/pierced-props',
     name: 'Pierced Props',
     component: () => import('../../pages/basic/PiercedProps.vue'),

--- a/src/core/nodeOps.test.ts
+++ b/src/core/nodeOps.test.ts
@@ -301,35 +301,25 @@ describe('nodeOps', () => {
       expect(node.defines[allCapsUnderscoresKey]).equals(allCapsUnderscoresValue)
     })
 
-    it('sets "on*" callbacks on Object3D', () => {
+    it('replaces "on*" methods on Object3D', () => {
       // Issue: https://github.com/Tresjs/tres/issues/360
       const { createElement, patchProp } = nodeOps
       const object = createElement('TresObject3D', undefined, undefined, {})
 
-      const onAfterRender = vi.fn()
-      const onAfterShadow = vi.fn()
-      const onBeforeRender = vi.fn()
-      const onBeforeShadow = vi.fn()
+      const onAfterRender = () => {}
+      const onAfterShadow = () => {}
+      const onBeforeRender = () => {}
+      const onBeforeShadow = () => {}
 
       patchProp(object, 'onAfterRender', null, onAfterRender)
       patchProp(object, 'onAfterShadow', null, onAfterShadow)
       patchProp(object, 'onBeforeRender', null, onBeforeRender)
       patchProp(object, 'onBeforeShadow', null, onBeforeShadow)
 
-      expect(onAfterRender).not.toBeCalled()
-      expect(onAfterShadow).not.toBeCalled()
-      expect(onBeforeRender).not.toBeCalled()
-      expect(onBeforeShadow).not.toBeCalled()
-
-      object.onAfterRender()
-      object.onAfterShadow()
-      object.onBeforeRender()
-      object.onBeforeShadow()
-
-      expect(onAfterRender).toBeCalled()
-      expect(onAfterShadow).toBeCalled()
-      expect(onBeforeRender).toBeCalled()
-      expect(onBeforeShadow).toBeCalled()
+      expect(object.onAfterRender).toBe(onAfterRender)
+      expect(object.onAfterShadow).toBe(onAfterShadow)
+      expect(object.onBeforeRender).toBe(onBeforeRender)
+      expect(object.onBeforeShadow).toBe(onBeforeShadow)
     })
 
     it('calls object methods', () => {

--- a/src/core/nodeOps.test.ts
+++ b/src/core/nodeOps.test.ts
@@ -301,6 +301,37 @@ describe('nodeOps', () => {
       expect(node.defines[allCapsUnderscoresKey]).equals(allCapsUnderscoresValue)
     })
 
+    it('sets "on*" callbacks on Object3D', () => {
+      // Issue: https://github.com/Tresjs/tres/issues/360
+      const { createElement, patchProp } = nodeOps
+      const object = createElement('TresObject3D', undefined, undefined, {})
+
+      const onAfterRender = vi.fn()
+      const onAfterShadow = vi.fn()
+      const onBeforeRender = vi.fn()
+      const onBeforeShadow = vi.fn()
+
+      patchProp(object, 'onAfterRender', null, onAfterRender)
+      patchProp(object, 'onAfterShadow', null, onAfterShadow)
+      patchProp(object, 'onBeforeRender', null, onBeforeRender)
+      patchProp(object, 'onBeforeShadow', null, onBeforeShadow)
+
+      expect(onAfterRender).not.toBeCalled()
+      expect(onAfterShadow).not.toBeCalled()
+      expect(onBeforeRender).not.toBeCalled()
+      expect(onBeforeShadow).not.toBeCalled()
+
+      object.onAfterRender()
+      object.onAfterShadow()
+      object.onBeforeRender()
+      object.onBeforeShadow()
+
+      expect(onAfterRender).toBeCalled()
+      expect(onAfterShadow).toBeCalled()
+      expect(onBeforeRender).toBeCalled()
+      expect(onBeforeShadow).toBeCalled()
+    })
+
     it('calls object methods', () => {
       const camera = nodeOps.createElement('TresPerspectiveCamera', undefined, undefined, {})
       const spy = vi.spyOn(camera, 'lookAt')

--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -272,6 +272,11 @@ export const nodeOps: () => RendererOptions<TresObject, TresObject | null> = () 
           if (Array.isArray(value)) { node[finalKey](...value) }
           else { node[finalKey](value) }
         }
+        // NOTE: Set on* callbacks
+        // Issue: https://github.com/Tresjs/tres/issues/360
+        if (finalKey.startsWith('on') && isFunction(value)) {
+          root[finalKey] = value
+        }
         return
       }
       if (!target?.set && !isFunction(target)) { root[finalKey] = value }


### PR DESCRIPTION
## Problem

`on*` callbacks – e.g., `onBeforeRender` – are methods on THREE Objects. In plain THREE, these can be overridden by users. 

Currently in TresJS, a prop like `on-before-render="..."` calls the default function – which does nothing:

* https://github.com/mrdoob/three.js/blob/a2e9ee8204b67f9dca79f48cf620a34a05aa8126/src/materials/Material.js#L105
* https://github.com/mrdoob/three.js/blob/a2e9ee8204b67f9dca79f48cf620a34a05aa8126/src/core/Object3D.js#L123

It should instead *set* the function.

## Solution

Add a predicate in `src/core/nodeOps.ts` where, for `prop-name="value"`:

* `prop-name` starts with `on`
* `object[propName]` is a function
* `value` is a function

In this limited case, `value` will replace `object[propName]`.

A unit test and a playground were also added.

## Context

This is a more targeted approach than R3F. There's a good chance that this could be absorbed into a more general predicate in a future refactor.

But the predicate is kept tight here to avoid unexpected behavior elsewhere.

Closes #360