### PR TITLE
fix: start loop if user calls `useRenderLoop`

### DIFF
--- a/src/composables/useRenderLoop/index.ts
+++ b/src/composables/useRenderLoop/index.ts
@@ -40,7 +40,16 @@ onAfterLoop.on(() => {
   elapsed = clock.getElapsedTime()
 })
 
+let startedOnce = false
 export const useRenderLoop = (): UseRenderLoopReturn => {
+  if (!startedOnce) {
+    // NOTE: `useRenderLoop` is not started by default
+    // in order not to waste user resources. Instead, we'll
+    // start the loop the first time the user uses
+    // `useRenderLoop`.
+    startedOnce = true
+    resume()
+  }
   return {
     onBeforeLoop: onBeforeLoop.on,
     onLoop: onLoop.on,


### PR DESCRIPTION
## Problem

`useRenderLoop` used to be `resume()`d by default. `resume()` starts the loop, calling the users callbacks without the user needing to call `resume` themselves.

Since `v4` the `useRenderLoop` is not started by default. This results in:

* playgrounds/demos not working
* a change in the behavior of existing user code

At the same time, `useRenderLoop` is no longer Tres' preferred way of looping. So it shouldn't consume resources unless necessary.

## Solution

On the first call to `useRenderLoop`, `resume` the loop.