### PR TITLE
refactor: update and maintain __tres parent/objects graph

### DIFF
--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -121,6 +121,10 @@ export const nodeOps: (context: TresContext) => RendererOptions<TresObject, Tres
       child.dispatchEvent({ type: 'added' })
     }
     else if (is.fog(child)) {
+      // TODO
+      // Currently `material` and `geometry` are attached by
+      // setting `attach` in `createElement`.
+      // Do the same here to eliminate this branch.
       parentObject.fog = child
     }
     else if (typeof child.attach === 'string') {
@@ -134,6 +138,10 @@ export const nodeOps: (context: TresContext) => RendererOptions<TresObject, Tres
   function remove(node: TresObject | null) {
     if (!node) { return }
     // remove is only called on the node being removed and not on child nodes.
+
+    // TODO:
+    // Figure out why `parent` is being set on `node` here
+    // and remove/refactor.
     node.parent = node.parent || scene
 
     if (is.object3D(node)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,15 +42,22 @@ interface TresBaseObject {
 
 export interface LocalState {
   type: string
-  // objects and parent are used when children are added with `attach` instead of being added to the Object3D scene graph
-  objects?: TresObject3D[]
-  parent?: TresObject3D | null
+  eventCount: number
+  root: TresContext
+  handlers: Partial<EventHandlers>
+  memoizedProps: { [key: string]: any }
+  // NOTE:
+  // LocalState holds information about the parent/child relationship
+  // in the Vue graph. If a child is `insert`ed into a parent using
+  // anything but THREE's `add`, it's put into the parent's `objects`.
+  // objects and parent are used when children are added with `attach`
+  // instead of being added to the Object3D scene graph
+  objects: TresObject[]
+  parent: TresObject | null
+  // NOTE: End graph info
+
   primitive?: boolean
-  eventCount?: number
-  handlers?: Partial<EventHandlers>
-  memoizedProps?: { [key: string]: any }
   disposable?: boolean
-  root?: TresContext
 }
 
 // Custom type for geometry and material properties in Object3D
@@ -61,6 +68,8 @@ export interface TresObject3D extends THREE.Object3D<THREE.Object3DEventMap> {
 
 export type TresObject =
   TresBaseObject & (TresObject3D | THREE.BufferGeometry | THREE.Material | THREE.Fog) & { __tres?: LocalState }
+
+export type TresInstance = TresObject & { __tres: LocalState }
 
 export interface TresScene extends THREE.Scene {
   __tres: {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,62 @@
+import * as utils from './index'
+
+describe('filterInPlace', () => {
+  it('returns the passed array', () => {
+    const arr = [1, 2, 3]
+    const result = utils.filterInPlace(arr, v => v !== 0)
+    expect(result).toBe(arr)
+  })
+  it('removes a single occurence', () => {
+    const arr = [1, 2, 3]
+    utils.filterInPlace(arr, v => v !== 1)
+    expect(arr).toStrictEqual([2, 3])
+  })
+  it('removes every occurence 0', () => {
+    const arr = [1, 1, 2, 1, 3, 1]
+    utils.filterInPlace(arr, v => v !== 1)
+    expect(arr).toStrictEqual([2, 3])
+  })
+
+  it('removes every occurence 1', () => {
+    const [a, b, c] = [{}, {}, {}]
+    const COUNT = 400
+    const arr = []
+    for (const val of [a, b, c]) {
+      for (let i = 0; i < COUNT; i++) {
+        arr.push(val)
+      }
+    }
+    shuffle(arr)
+
+    let filtered = [...arr]
+    utils.filterInPlace(arr, v => v !== b)
+    filtered = filtered.filter(v => v !== b)
+    expect(arr).toStrictEqual(filtered)
+
+    utils.filterInPlace(arr, v => v !== c)
+    filtered = filtered.filter(v => v !== c)
+    expect(arr).toStrictEqual(filtered)
+
+    utils.filterInPlace(arr, v => v !== a)
+    expect(arr).toStrictEqual([])
+  })
+
+  it('sends an index to the callbackFn', () => {
+    const arr = 'abcdefghi'.split('')
+    utils.filterInPlace(arr, (_, i) => i % 2 === 0)
+    expect(arr).toStrictEqual('acegi'.split(''))
+  })
+})
+
+function shuffle(array: any[]) {
+  let currentIndex = array.length
+  while (currentIndex !== 0) {
+    const randomIndex = Math.floor(Math.random() * currentIndex)
+    currentIndex--;
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex],
+      array[currentIndex],
+    ]
+  }
+  return array
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -313,3 +313,20 @@ export function disposeObject3D(object: TresObject): void {
     }
   }
 }
+
+/**
+ * Like Array.filter, but modifies the array in place.
+ * @param array - Array to modify
+ * @param callbackFn - A function called for each element of the array. It should return a truthy value to keep the element in the array.
+ */
+export function filterInPlace<T>(array: T[], callbackFn: (element: T, index: number) => unknown) {
+  let i = 0
+  for (let ii = 0; ii < array.length; ii++) {
+    if (callbackFn(array[ii], ii)) {
+      array[i] = array[ii]
+      i++
+    }
+  }
+  array.length = i
+  return array
+}


### PR DESCRIPTION
This is a refactor in support of #701 .

The existing `parent`/`objects` fields on `__tres` were unused. These are required for proper disposal of primitives – among other this.

With this PR, the `parent/objects` graph is now maintained when nodes are `insert`ed and `remove`d in nodeOps.

* `parent` is the parent of a `TresObject`
* `object` is any `TresObject` that **isn't** in `children`, i.e., an `object` is **not** inserted into the scene graph using `THREE`'s `add()`. 