### PR TITLE
support Symbol keys in provide/inject (fix #849)

### DIFF
--- a/playground/vue/src/pages/issues/732/SubComponentWithInject.vue
+++ b/playground/vue/src/pages/issues/732/SubComponentWithInject.vue
@@ -1,15 +1,19 @@
 <!-- eslint-disable no-console -->
 <script setup lang="ts">
 import { inject, watchEffect } from 'vue'
+import { injectSymbol } from './constants'
 
 const awiwi = inject('awiwi')
 const bululu = inject('bululu')
+const symbolInjection = inject(injectSymbol)
 const vRoute = inject('v-route')
 console.log(inject('test'))
 
 watchEffect(() => console.log('tres:awiwi', awiwi?.a))
 
 watchEffect(() => console.log('tres:bululu', bululu?.value))
+
+watchEffect(() => console.log('tres:symbolInjection', symbolInjection?.value))
 
 watchEffect(() => console.log('tres:v-route', vRoute))
 

--- a/playground/vue/src/pages/issues/732/SubVueComponentWithInject.vue
+++ b/playground/vue/src/pages/issues/732/SubVueComponentWithInject.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import { inject, watchEffect } from 'vue'
+import { injectSymbol } from './constants'
 
 const awiwi = inject('awiwi')
 const bululu = inject('bululu')
+const symbolInjection = inject(injectSymbol)
 // eslint-disable-next-line no-console
 watchEffect(() => console.log('vue:awiwi', awiwi?.a))
 // eslint-disable-next-line no-console
 watchEffect(() => console.log('vue:bululu', bululu?.value))
+// eslint-disable-next-line no-console
+watchEffect(() => console.log('vue:symbolInjection', symbolInjection?.value))
 // eslint-disable-next-line no-console
 watchEffect(() => console.log('vue:v-route', inject('v-route')))
 // eslint-disable-next-line no-console
@@ -16,5 +20,6 @@ watchEffect(() => console.log('vue:useTres', inject('useTres')))
 <template>
   <p>awiwi: {{ awiwi }}</p>
   <p>bululu: {{ bululu }}</p>
+  <p>symbolInjection: {{ symbolInjection }}</p>
   <p>v-route: {{ inject('v-route') }}</p>
 </template>

--- a/playground/vue/src/pages/issues/732/constants.ts
+++ b/playground/vue/src/pages/issues/732/constants.ts
@@ -1,0 +1,1 @@
+export const injectSymbol = Symbol('inject')

--- a/playground/vue/src/pages/issues/732/index.vue
+++ b/playground/vue/src/pages/issues/732/index.vue
@@ -3,14 +3,17 @@ import { provide, reactive } from 'vue'
 
 import ProvideInjectExperience from './ProvideInjectExperience.vue'
 import SubVueComponentWithInject from './SubVueComponentWithInject.vue'
+import { injectSymbol } from './constants'
 
 const obj = reactive({
   a: 1,
 })
 const bululu = ref(1)
+const symbolInjection = computed(() => `Symbol injection is working  ${obj.a}`)
 provide('awiwi', obj)
 provide('bululu', bululu)
 provide('test', '❌ Precendence is incorrect')
+provide(injectSymbol, symbolInjection)
 function onClick() {
   obj.a++
   bululu.value++

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -116,7 +116,7 @@ const createInternalComponent = (context: TresContext, empty = false) =>
     setup() {
       const ctx = getCurrentInstance()?.appContext
       if (ctx) { ctx.app = instance?.appContext.app as App }
-      const provides = {}
+      const provides: { [key: string | symbol]: unknown } = {}
 
       // Helper function to recursively merge provides from parents
       function mergeProvides(currentInstance: any) {
@@ -136,9 +136,9 @@ const createInternalComponent = (context: TresContext, empty = false) =>
       if (instance?.parent && props.enableProvideBridge) {
         mergeProvides(instance.parent)
 
-        Object.entries(provides)
-          .forEach(([key, value]) => {
-            provide(key, value)
+        Reflect.ownKeys(provides)
+          .forEach((key) => {
+            provide(key, provides[key])
           })
       }
 


### PR DESCRIPTION
As `Object.entries(...)` only lists string properties, and Vue supports provide/inject [with Symbols as keys](https://vuejs.org/guide/components/provide-inject#working-with-symbol-keys), all provisions are not picked up.

I opted for `Reflect.ownKeys`, as its a good choice per the MDN documentation:

[Object.entries()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)

 > The Object.entries() static method returns an array of a given object's **own enumerable string-keyed property** key-value pairs.

[Reflect.ownKeys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys)

> The Reflect.ownKeys() static method returns an array of the target object's **own property keys**

> Return Value
> Array of the target object's own property keys, **including strings and symbols**. For most objects, the array will be in the order of:

I've modified the #732 example to add the symbols. Prior to my change, this is the output:

![Screenshot 2024-10-04 at 15 10 29](https://github.com/user-attachments/assets/5d260552-33e6-4f82-8eaf-1747eaedd6f5)

And with my changes it's this

![Screenshot 2024-10-04 at 15 19 37](https://github.com/user-attachments/assets/7f070ff3-2c68-4806-9100-3bd414c47acb)
