### PR TITLE
feat: extend GlobalComponents interface to include 'primitive' component type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -233,11 +233,17 @@ type TresComponents = {
 }
 
 declare module 'vue' {
-  export interface GlobalComponents extends TresComponents { }
+  export interface GlobalComponents extends TresComponents {
+    primitive: DefineComponent<TresPrimitive>
+  }
 }
 declare module '@vue/runtime-core' {
-  interface GlobalComponents extends TresComponents { }
+  interface GlobalComponents extends TresComponents {
+    primitive: DefineComponent<TresPrimitive>
+  }
 }
 declare module '@vue/runtime-dom' {
-  interface GlobalComponents extends TresComponents {}
+  interface GlobalComponents extends TresComponents {
+    primitive: DefineComponent<TresPrimitive>
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,13 +237,3 @@ declare module 'vue' {
     primitive: DefineComponent<TresPrimitive>
   }
 }
-declare module '@vue/runtime-core' {
-  interface GlobalComponents extends TresComponents {
-    primitive: DefineComponent<TresPrimitive>
-  }
-}
-declare module '@vue/runtime-dom' {
-  interface GlobalComponents extends TresComponents {
-    primitive: DefineComponent<TresPrimitive>
-  }
-}


### PR DESCRIPTION
This PR adds the definition of primitive components to the global augmentation 

Closes #895 