### PR TITLE
Remove unescessary call to getElapsedTime

### DIFF
--- a/src/composables/useRenderLoop/index.ts
+++ b/src/composables/useRenderLoop/index.ts
@@ -37,7 +37,7 @@ const { pause, resume, isActive } = useRafFn(
 
 onAfterLoop.on(() => {
   delta = clock.getDelta()
-  elapsed = clock.getElapsedTime()
+  elapsed = clock.elapsedTime
 })
 
 let startedOnce = false

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -123,7 +123,7 @@ export function createRenderLoop(): RendererLoop {
       return
     }
     const delta = clock.getDelta()
-    const elapsed = clock.getElapsedTime()
+    const elapsed = clock.elapsedTime
     const snapshotCtx = {
       camera: unref(context.camera),
       scene: unref(context.scene),


### PR DESCRIPTION
The call is not causing any bug since it is called immediatly after `getDelta` but it is doing a duplicate job with `getDelta()` that is already updating the `.elapsedTime` property.

https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js#L58 