### PR TITLE
docs: correct link to tweakpane in english docs

### DIFF
--- a/docs/cookbook/tweakpane.md
+++ b/docs/cookbook/tweakpane.md
@@ -8,7 +8,7 @@ difficulty: 0
 
 # Tweakpane
 
-To make it easier to control the parameters of your scene, you can use [Tweakpane](https://cocopon.github.io/tweakpane/). In this guide, we will show you how to use Tweakpane to control the parameters of your scene.
+To make it easier to control the parameters of your scene, you can use [Tweakpane](https://tweakpane.github.io/docs/). In this guide, we will show you how to use Tweakpane to control the parameters of your scene.
 
 <StackBlitzEmbed project-id="tweakpane" />
 


### PR DESCRIPTION
It looks like the maintainer of Tweakpane has changed something in the organisation and how the link for the documentation Github pages is created. 


PS: Since it's such a small change I did not create a Github issue for this change. 