### PR TITLE
Fix import of vLightHelper

### DIFF
--- a/docs/de/directives/v-light-helper.md
+++ b/docs/de/directives/v-light-helper.md
@@ -12,7 +12,8 @@ Die folgenden Lichter werden unterstützt:
 
 ```vue{2,8,11,14,17}
 <script setup lang="ts">
-import { OrbitControls, Sphere, vLightHelper } from '@tresjs/cientos'
+import { vLightHelper } from '@tresjs/core'
+import { OrbitControls, Sphere } from '@tresjs/cientos'
 </script>
 <template>
   <TresCanvas >


### PR DESCRIPTION
Changed the import of `vLightHelper` from `@tresjs/cientos` to `@tresjs/core`. (as seen in the untranslated documentation)