### PR TITLE
feat!: drop umd bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/tres.js",
-      "require": "./dist/tres.umd.cjs"
+      "import": "./dist/tres.js"
     },
     "./components": {
       "types": "./dist/src/components/index.d.ts"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,10 +46,12 @@ export default defineConfig({
     threads: false,
   },
   build: {
+    // vite.config.ts
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'tres',
       fileName: 'tres',
+      formats: ['es'],
     },
     watch: {
       include: [resolve(__dirname, 'src')],
@@ -71,13 +73,6 @@ export default defineConfig({
       external: ['vue', '@vueuse/core', 'three'],
       output: {
         exports: 'named',
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          'vue': 'Vue',
-          '@vueuse/core': 'VueUseCore',
-          'three': 'Three',
-        },
       },
     },
   },


### PR DESCRIPTION
BREAKING CHANGE: Tres is now ESM only

- Removed UMD build configuration from package.json and adjusted exports to only include ES module.
- Updated vite.config.ts to specify the output format as ES, enhancing compatibility with modern module systems.

Closes #947