### PR TITLE
fix: export logger utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './core/catalogue'
 export * from './core/loop'
 export * from './directives'
 export * from './types'
+export * from './utils/logger'
 
 export interface TresOptions {
   extends?: Record<string, unknown>


### PR DESCRIPTION
- Added export for the logger utility from './utils/logger' to enhance logging capabilities across the ecosystem