### PR TITLE
fix: linter findings and force linter to be executed on every push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
 name: Run linters
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   PNPM_CACHE_FOLDER: .pnpm-store

--- a/docs/team.md
+++ b/docs/team.md
@@ -26,13 +26,13 @@ import { core, maintainers, alumni } from './_data/team'
     <template #members>
       <VPTeamMembers :members="core" />
     </template>
-  </VPTeamPageSection> 
+  </VPTeamPageSection>
   <VPTeamPageSection>
     <template #title>Maintainers</template>
     <template #members>
       <VPTeamMembers :members="maintainers" />
     </template>
-  </VPTeamPageSection> 
+  </VPTeamPageSection>
   <VPTeamPageSection>
     <template #title>Alumni</template>
     <template #lead>
@@ -42,5 +42,5 @@ import { core, maintainers, alumni } from './_data/team'
     <template #members>
       <VPTeamMembers size="small" :members="alumni" />
     </template>
-  </VPTeamPageSection> 
+  </VPTeamPageSection>
 </VPTeamPage>


### PR DESCRIPTION
I noticed that the linter check was executed but only on master and some of my linter findings were not checked. 🤔 

I fixed them in this PR and changed the workflow to be executed on every push to a PR or to main. 
The same syntax is also on the test workflow, maybe that one needs also that change. Happy to address this as well. 
I circled back to the last PR and couldn't find an execution also not in the actions tab for that PR, which was very confusing considering the trigger was for all kinds of "push". 👀 

Maybe the Github action syntax was outdated, not sure though.