### PR TITLE
feat: 974-vue-devtools-api-v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@alvarosabu/utils": "^3.2.0",
-    "@vue/devtools-api": "^6.6.3",
+    "@vue/devtools-api": "^7.7.2",
     "@vueuse/core": "^12.5.0"
   },
   "devDependencies": {

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tresjs/cientos": "4.1.0",
+    "@tresjs/cientos": "https://pkg.pr.new/@tresjs/cientos@d84eb13",
     "@tresjs/core": "workspace:^",
     "@tresjs/leches": "https://pkg.pr.new/@tresjs/leches@9ad0cd3",
     "vue-router": "^4.5.0"

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -7,7 +7,7 @@ import Components from 'unplugin-vue-components/vite'
 import { defineConfig } from 'vite'
 import glsl from 'vite-plugin-glsl'
 import { qrcode } from 'vite-plugin-qrcode'
-/* import VueDevTools from 'vite-plugin-vue-devtools' */
+import VueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -38,7 +38,8 @@ export default defineConfig({
         },
       },
     }),
-    qrcode(), // only applies in dev mode
+    qrcode(), // only applies in dev mode,
+    VueDevTools(),
   ],
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       '@vue/devtools-api':
-        specifier: ^6.6.3
-        version: 6.6.4
+        specifier: ^7.7.2
+        version: 7.7.2
       '@vueuse/core':
         specifier: ^12.5.0
         version: 12.7.0(typescript@5.7.3)
@@ -164,8 +164,8 @@ importers:
   playground/vue:
     dependencies:
       '@tresjs/cientos':
-        specifier: 4.1.0
-        version: 4.1.0(@tresjs/core@)(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
+        specifier: https://pkg.pr.new/@tresjs/cientos@d84eb13
+        version: https://pkg.pr.new/@tresjs/cientos@d84eb13(@tresjs/core@)(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
       '@tresjs/core':
         specifier: workspace:^
         version: link:../..
@@ -1658,6 +1658,14 @@ packages:
 
   '@tresjs/cientos@4.1.0':
     resolution: {integrity: sha512-vhYQ6HbcuswLngyHgHj+L6FAgtedhmbH83+xQbPgJmEGAUqu+91PQeH+Hujgk/6U444hObq1FwUZWClrrjXatQ==}
+    peerDependencies:
+      '@tresjs/core': '>=4.2.1'
+      three: '>=0.133'
+      vue: '>=3.3'
+
+  '@tresjs/cientos@https://pkg.pr.new/@tresjs/cientos@d84eb13':
+    resolution: {tarball: https://pkg.pr.new/@tresjs/cientos@d84eb13}
+    version: 4.2.0
     peerDependencies:
       '@tresjs/core': '>=4.2.1'
       three: '>=0.133'
@@ -6944,9 +6952,9 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tresjs/cientos@4.1.0(@tresjs/core@)(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))':
+  '@tresjs/cientos@4.1.0(@tresjs/core@4.3.3(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      '@tresjs/core': 'link:'
+      '@tresjs/core': 4.3.3(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
       '@vueuse/core': 12.7.0(typescript@5.7.3)
       camera-controls: 2.10.0(three@0.173.0)
       stats-gl: 2.4.2(@types/three@0.173.0)(three@0.173.0)
@@ -6961,10 +6969,10 @@ snapshots:
       - react
       - typescript
 
-  '@tresjs/cientos@4.1.0(@tresjs/core@4.3.3(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))':
+  '@tresjs/cientos@https://pkg.pr.new/@tresjs/cientos@d84eb13(@tresjs/core@)(@types/three@0.173.0)(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      '@tresjs/core': 4.3.3(three@0.173.0)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
-      '@vueuse/core': 12.7.0(typescript@5.7.3)
+      '@tresjs/core': 'link:'
+      '@vueuse/core': 12.8.2(typescript@5.7.3)
       camera-controls: 2.10.0(three@0.173.0)
       stats-gl: 2.4.2(@types/three@0.173.0)(three@0.173.0)
       stats.js: 0.17.0

--- a/src/devtools/plugin.ts
+++ b/src/devtools/plugin.ts
@@ -1,6 +1,3 @@
-import type {
-  App as DevtoolsApp,
-} from '@vue/devtools-api'
 import type { TresContext } from '../composables'
 import type { TresObject } from './../types'
 import {
@@ -113,14 +110,14 @@ const state = reactive({
   sceneGraph: null as SceneGraphObject | null,
 })
 
-export function registerTresDevtools(app: DevtoolsApp, tres: TresContext) {
+export function registerTresDevtools(app: any, tres: TresContext) {
   setupDevtoolsPlugin(
     {
       id: 'dev.esm.tres',
       label: 'TresJS 🪐',
       logo: 'https://raw.githubusercontent.com/Tresjs/tres/main/public/favicon.svg',
       packageName: 'tresjs',
-      homepage: 'https://tresjs.org',
+      homepage: 'https://docs.tresjs.org',
       componentStateTypes,
       app,
     },


### PR DESCRIPTION
- Upgraded @vue/devtools-api from version 6.6.3 to 7.7.2 for improved functionality.
- Updated @tresjs/cientos dependency to a specific version hosted at a new URL for better version control.
- Enabled Vue DevTools in the Vite configuration for enhanced development experience.
- Adjusted the homepage link in the devtools plugin for accurate documentation reference.