### PR TITLE
fix(patchProp): harden props inference

### DIFF
--- a/src/core/nodeOps.test.ts
+++ b/src/core/nodeOps.test.ts
@@ -1343,7 +1343,7 @@ describe('nodeOps', () => {
         const s = v => JSON.stringify(v)
         const camera = nodeOps.createElement('TresPerspectiveCamera', undefined, undefined, {})
         const result = []
-        camera.position.set = (x, y, z) => result.push({ x, y, z })
+        camera.position.fromArray = ([x, y, z]: THREE.Vector3Tuple) => result.push({ x, y, z })
         nodeOps.patchProp(camera, 'position', undefined, [0, 0, 0])
         nodeOps.patchProp(camera, 'position', undefined, [1, 2, 3])
         nodeOps.patchProp(camera, 'position', undefined, [4, 5, 6])

--- a/src/core/nodeOps.ts
+++ b/src/core/nodeOps.ts
@@ -315,7 +315,7 @@ export const nodeOps: (context: TresContext) => RendererOptions<TresObject, Tres
       target = root
       for (const part of key.split('-')) {
         finalKey = key = kebabToCamel(part)
-        root = target as any
+        root = target
         target = target?.[key] as Record<string, unknown>
       }
     }

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,5 +1,6 @@
 import type { TresObject, TresPrimitive } from 'src/types'
-import type { BufferGeometry, Camera, Fog, Light, Material, Object3D, Scene } from 'three'
+import type { BufferGeometry, Camera, Color, ColorRepresentation, Fog, Light, Material, Object3D, Scene } from 'three'
+import { Layers } from 'three'
 
 export function und(u: unknown): u is undefined {
   return typeof u === 'undefined'
@@ -31,6 +32,33 @@ export function obj(u: unknown): u is Record<string | number | symbol, unknown> 
 
 export function object3D(u: unknown): u is Object3D {
   return obj(u) && !!(u.isObject3D)
+}
+
+export function color(u: unknown): u is Color {
+  return obj(u) && !!(u.isColor)
+}
+
+export function colorRepresentation(u: unknown): u is ColorRepresentation {
+  return u != null && (typeof u === 'string' || typeof u === 'number' || color(u))
+}
+
+interface VectorLike { set: (...args: any[]) => void, constructor?: (...args: any[]) => any }
+export function vectorLike(u: unknown): u is VectorLike {
+  return u !== null && typeof u === 'object' && 'set' in u && typeof u.set === 'function'
+}
+
+interface Copyable { copy: (...args: any[]) => void, constructor?: (...args: any[]) => any }
+export function copyable(u: unknown): u is Copyable {
+  return vectorLike(u) && 'copy' in u && typeof u.copy === 'function'
+}
+
+interface ClassInstance { constructor?: (...args: any[]) => any }
+export function classInstance(object: unknown): object is ClassInstance {
+  return !!(object as any)?.constructor
+}
+
+export function layers(u: unknown): u is Layers {
+  return u instanceof Layers // three does not implement .isLayers
 }
 
 export function camera(u: unknown): u is Camera {


### PR DESCRIPTION
Hardens inference in `patchProp`, where unsafe property access was permitted before. This aligns with R3F v9.

This fixes edge cases like https://github.com/pmndrs/koota/issues/58, where inference can be fooled into breaking setters for non-atomic values.