### PR TITLE
refactor: remove redundant error check in invalidate function of useRendererManager

### DIFF
--- a/src/composables/useRenderer/useRendererManager.ts
+++ b/src/composables/useRenderer/useRendererManager.ts
@@ -146,8 +146,6 @@ export function useRendererManager(
    */
   const invalidate = (amountOfFramesToInvalidate = 1) => {
     if (!canBeInvalidated.value) {
-      if (toValue(options.renderMode) !== 'on-demand') { throw new Error('invalidate can only be called in on-demand render mode.') }
-
       return
     }
 


### PR DESCRIPTION
- Removed the error check for render mode in the `invalidate` function, as it is no longer necessary. This simplifies the logic and improves code clarity.