### PR TITLE
feat: webgpu native support

### DIFF
--- a/playground/vue/src/pages/advanced/webGPU/HologramCube.vue
+++ b/playground/vue/src/pages/advanced/webGPU/HologramCube.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { useGLTF } from '@tresjs/cientos'
+import { add, cameraProjectionMatrix, cameraViewMatrix, color, Fn, hash, mix, normalView, positionWorld, sin, timerGlobal, uniform, varying, vec3, vec4 } from 'three/tsl'
+import { AdditiveBlending, DoubleSide, MeshBasicNodeMaterial } from 'three/webgpu'
+
+const { nodes } = useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/blender-cube.glb', { draco: true })
+
+const model = computed(() => nodes.value.BlenderCube)
+/**
+ * Material
+ */
+const material = new MeshBasicNodeMaterial({
+  transparent: true,
+  side: DoubleSide,
+  depthWrite: false,
+  blending: AdditiveBlending,
+})
+// Position
+const glitchStrength = varying(0)
+material.vertexNode = Fn(() => {
+  const glitchTime = timerGlobal().sub(positionWorld.y.mul(0.5))
+  glitchStrength.assign(add(
+    sin(glitchTime),
+    sin(glitchTime.mul(3.45)),
+    sin(glitchTime.mul(8.76)),
+  ).div(3).smoothstep(0.3, 1))
+  const glitch = vec3(
+    hash(positionWorld.xz.abs().mul(9999)).sub(0.5),
+    0,
+    hash(positionWorld.yx.abs().mul(9999)).sub(0.5),
+  )
+  positionWorld.xyz.addAssign(glitch.mul(glitchStrength.mul(0.5)))
+  return cameraProjectionMatrix.mul(cameraViewMatrix).mul(positionWorld)
+})()
+// Color
+const colorInside = uniform(color('#ff6088'))
+const colorOutside = uniform(color('#4d55ff'))
+material.colorNode = Fn(() => {
+  const stripes = positionWorld.y.sub(timerGlobal(0.02)).mul(20).mod(1).pow(3)
+  const fresnel = normalView.dot(vec3(0, 0, 1)).abs().oneMinus()
+  const falloff = fresnel.smoothstep(0.8, 0.2)
+  const alpha = stripes.mul(fresnel).add(fresnel.mul(1.25)).mul(falloff)
+  const finalColor = mix(colorInside, colorOutside, fresnel.add(glitchStrength.mul(0.6)))
+  return vec4(finalColor, alpha)
+})()
+
+watch(model, (newModel) => {
+  newModel.traverse((child) => {
+    if (child.isMesh) {
+      child.material = material
+    }
+  })
+})
+</script>
+
+<template>
+  <primitive v-if="model" :object="model" />
+</template>

--- a/playground/vue/src/pages/advanced/webGPU/index.vue
+++ b/playground/vue/src/pages/advanced/webGPU/index.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { WebGPURenderer } from 'three/webgpu'
+import type { ShadowMapType, ToneMapping } from 'three'
+import type { TresRendererSetupContext } from '@tresjs/core'
+import { ACESFilmicToneMapping, AgXToneMapping, BasicShadowMap, CineonToneMapping, LinearToneMapping, NeutralToneMapping, NoToneMapping, PCFShadowMap, PCFSoftShadowMap, ReinhardToneMapping, VSMShadowMap } from 'three'
+import { OrbitControls } from '@tresjs/cientos'
+import { TresLeches, useControls } from '@tresjs/leches'
+import '@tresjs/leches/styles'
+
+import HologramCube from './HologramCube.vue'
+
+const createWebGPURenderer = (ctx: TresRendererSetupContext) => {
+  const renderer = new WebGPURenderer({
+    canvas: toValue(ctx.canvas),
+    // WebGPU specific configuration
+    alpha: true,
+    antialias: true,
+  })
+  return renderer
+}
+
+const { clearColor, clearAlpha, toneMapping, shadows, shadowMapType } = useControls({
+  clearColor: '#000000',
+  clearAlpha: {
+    value: 1,
+    min: 0,
+    max: 1,
+    step: 0.01,
+    label: 'Clear Alpha',
+  },
+  toneMapping: {
+    value: ACESFilmicToneMapping,
+    options: [
+      { text: 'No Tone Mapping', value: NoToneMapping },
+      { text: 'Linear', value: LinearToneMapping },
+      { text: 'Reinhard', value: ReinhardToneMapping },
+      { text: 'Cineon', value: CineonToneMapping },
+      { text: 'ACES Filmic', value: ACESFilmicToneMapping },
+      { text: 'AgX', value: AgXToneMapping }, // New in Three.js r155
+      { text: 'Neutral', value: NeutralToneMapping },
+    ],
+  },
+  shadows: true,
+  shadowMapType: {
+    value: PCFSoftShadowMap,
+    options: [
+      { text: 'Basic', value: BasicShadowMap },
+      { text: 'PCF', value: PCFShadowMap },
+      { text: 'PCF Soft', value: PCFSoftShadowMap },
+      { text: 'VSM', value: VSMShadowMap },
+    ],
+  },
+})
+
+const formattedToneMapping = computed(() => {
+  return Number(toneMapping.value) as ToneMapping
+})
+
+const formattedShadowMapType = computed(() => {
+  return Number(shadowMapType.value) as ShadowMapType
+})
+</script>
+
+<template>
+  <TresLeches />
+
+  <TresCanvas :renderer="createWebGPURenderer" :clear-color="clearColor" :clear-alpha="clearAlpha" :tone-mapping="formattedToneMapping" :shadows="shadows" :shadow-map-type="formattedShadowMapType">
+    <TresPerspectiveCamera
+      :position="[3, 3, 3]"
+      :look-at="[0, 0, 0]"
+    />
+    <Suspense>
+      <HologramCube />
+    </Suspense>
+    <OrbitControls />
+    <TresAmbientLight :intensity="1" />
+  </TresCanvas>
+</template>

--- a/playground/vue/src/pages/advanced/webGPU/index.vue
+++ b/playground/vue/src/pages/advanced/webGPU/index.vue
@@ -4,7 +4,7 @@ import { WebGPURenderer } from 'three/webgpu'
 import type { ShadowMapType, ToneMapping } from 'three'
 import type { TresRendererSetupContext } from '@tresjs/core'
 import { ACESFilmicToneMapping, AgXToneMapping, BasicShadowMap, CineonToneMapping, LinearToneMapping, NeutralToneMapping, NoToneMapping, PCFShadowMap, PCFSoftShadowMap, ReinhardToneMapping, VSMShadowMap } from 'three'
-import { OrbitControls } from '@tresjs/cientos'
+// import { OrbitControls } from '@tresjs/cientos'
 import { TresLeches, useControls } from '@tresjs/leches'
 import '@tresjs/leches/styles'
 
@@ -73,7 +73,7 @@ const formattedShadowMapType = computed(() => {
     <Suspense>
       <HologramCube />
     </Suspense>
-    <OrbitControls />
+    <!-- <OrbitControls /> -->
     <TresAmbientLight :intensity="1" />
   </TresCanvas>
 </template>

--- a/playground/vue/src/router/routes/advanced.ts
+++ b/playground/vue/src/router/routes/advanced.ts
@@ -54,4 +54,9 @@ export const advancedRoutes = [
     name: 'Memory Test: Tres Objects',
     component: () => import('../../pages/advanced/MemoryTresObjects.vue'),
   },
+  {
+    path: '/advanced/webgpu',
+    name: 'WebGPU',
+    component: () => import('../../pages/advanced/webGPU/index.vue'),
+  },
 ]

--- a/src/components/TresCanvas.vue
+++ b/src/components/TresCanvas.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import type {
+import {
+  ACESFilmicToneMapping,
+  PCFSoftShadowMap,
+  PerspectiveCamera,
+  Scene,
   WebGLRenderer,
 } from 'three'
 import type { App, Ref } from 'vue'
 import type { TresCamera, TresObject, TresScene } from '../types/'
-import { ACESFilmicToneMapping, PCFSoftShadowMap, PerspectiveCamera, Scene } from 'three'
 import type { PointerEvent } from '@pmndrs/pointer-events'
 import * as THREE from 'three'
 
@@ -24,7 +27,7 @@ import {
   watchEffect,
 } from 'vue'
 import pkg from '../../package.json'
-import type { RendererOptions, TresContext } from '../composables'
+import type { RendererOptions, TresContext, TresRenderer } from '../composables'
 import { useTresContextProvider } from '../composables'
 import { extend } from '../core/catalogue'
 import { nodeOps } from '../core/nodeOps'
@@ -54,7 +57,7 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
 
 const emit = defineEmits<{
   ready: [context: TresContext]
-  render: [renderer: WebGLRenderer]
+  render: [renderer: TresRenderer]
   pointermissed: [event: PointerEvent<MouseEvent>]
 } & {
   // all pointer events are supported because they bubble up
@@ -128,8 +131,10 @@ const dispose = (context: TresContext, force = false) => {
   disposeObject3D(context.scene.value as unknown as TresObject)
   if (force) {
     context.renderer.instance.dispose()
-    context.renderer.instance.renderLists.dispose()
-    context.renderer.instance.forceContextLoss()
+    if (context.renderer.instance instanceof WebGLRenderer) {
+      context.renderer.instance.renderLists.dispose()
+      context.renderer.instance.forceContextLoss()
+    }
   }
   (scene.value as TresScene).__tres = {
     root: context,

--- a/src/composables/useRenderer/useRendererManager.ts
+++ b/src/composables/useRenderer/useRendererManager.ts
@@ -9,9 +9,9 @@ import {
   useDevicePixelRatio,
 } from '@vueuse/core'
 import { Material, Mesh, WebGLRenderer } from 'three'
-import { computed, onUnmounted, readonly, ref, toValue, watch, watchEffect } from 'vue'
+import { computed, onUnmounted, ref, toValue, watch, watchEffect } from 'vue'
 import type { MaybeRef, ShallowRef } from 'vue'
-import { WebGPURenderer } from 'three/webgpu'
+import type { Renderer } from 'three/webgpu'
 
 // Solution taken from Thretle that actually support different versions https://github.com/threlte/threlte/blob/5fa541179460f0dadc7dc17ae5e6854d1689379e/packages/core/src/lib/lib/useRenderer.ts
 import { setPixelRatio } from '../../utils'
@@ -19,7 +19,8 @@ import { setPixelRatio } from '../../utils'
 import { logWarning } from '../../utils/logger'
 import type { SizesType } from '../useSizes'
 import type { UseCameraReturn } from '../useCamera'
-import type { TresScene } from 'src/types'
+import type { TresScene } from '../../types'
+import { isFunction, isObject } from '../../utils/is'
 
 /**
  * If set to 'on-demand', the scene will only be rendered when the current frame is invalidated
@@ -28,7 +29,7 @@ import type { TresScene } from 'src/types'
  */
 export type RenderMode = 'always' | 'on-demand' | 'manual'
 
-export type TresRenderer = WebGLRenderer | WebGPURenderer
+export type TresRenderer = WebGLRenderer | Renderer
 
 export interface RendererOptions {
   /**
@@ -206,23 +207,24 @@ export function useRendererManager(
     contextParts: { sizes, loop, camera },
   }: UseRendererOptions,
 ) {
-  let renderer: TresRenderer
+  const getRenderer = () => {
+    if (isFunction(options.renderer)) {
+      return options.renderer({
+        sizes,
+        scene,
+        camera,
+        loop,
+        canvas,
+      })
+    }
 
-  if (options.renderer && typeof options.renderer === 'function') {
-    renderer = options.renderer({
-      sizes,
-      scene,
-      camera,
-      loop,
-      canvas,
-    })
-  }
-  else {
-    renderer = new WebGLRenderer({
+    return new WebGLRenderer({
       ...options,
       canvas: unrefElement(canvas),
     })
   }
+
+  const renderer = getRenderer()
 
   const frames = ref(0)
   const maxFrames = 60
@@ -267,10 +269,17 @@ export function useRendererManager(
 
   const renderEventHook = createEventHook<TresRenderer>()
 
-  if (renderer instanceof WebGPURenderer) {
+  // be aware that the WebGLRenderer does not extend from Renderer
+  const isRenderer = (value: unknown): value is Renderer =>
+    isObject(value) && 'isRenderer' in value && Boolean(value.isRenderer)
+
+  const readyEventHook = createEventHook<TresRenderer>()
+  let hasTriggeredReady = false
+
+  if (isRenderer(renderer)) {
     // Initialize the WebGPU context
     renderer.init()
-    loop.setReady(true)
+    readyEventHook.trigger(renderer)
   }
 
   loop.register(() => {
@@ -284,13 +293,6 @@ export function useRendererManager(
       ? 1
       : Math.max(0, frames.value - 1)
   }, 'render')
-
-  const isReady = computed(() =>
-    !!(renderer.domElement.width && renderer.domElement.height),
-  )
-
-  const readyEventHook = createEventHook<TresRenderer>()
-  let hasTriggeredReady = false
 
   // Watch the sizes and invalidate the renderer when they change
   watch([sizes.width, sizes.height], () => {
@@ -398,7 +400,6 @@ export function useRendererManager(
 
   return {
     instance: renderer,
-    isReady: readonly(isReady),
     advance,
     onRender: renderEventHook.on,
     onReady: readyEventHook.on,

--- a/src/composables/useTres/index.ts
+++ b/src/composables/useTres/index.ts
@@ -37,8 +37,8 @@ export interface TresPartialContext extends Omit<TresContext, 'renderer' | 'came
   advance: () => void
 }
 
-export async function useTres(): Promise<TresPartialContext> {
-  const { scene, renderer, camera, sizes, controls, loop, extend, events } = await useTresContext()
+export function useTres(): TresPartialContext {
+  const { scene, renderer, camera, sizes, controls, loop, extend, events } = useTresContext()
 
   return {
     scene,

--- a/src/composables/useTres/index.ts
+++ b/src/composables/useTres/index.ts
@@ -1,16 +1,17 @@
 import type { ComputedRef } from 'vue'
 import type { TresContext } from '../useTresContextProvider'
 import { useTresContext } from '../useTresContextProvider'
-import type { Camera, WebGLRenderer } from 'three'
+import type { Camera } from 'three'
+import type { TresRenderer } from '..'
 
 export interface TresPartialContext extends Omit<TresContext, 'renderer' | 'camera'> {
   /**
    * The renderer instance
    *
-   * @type {WebGLRenderer}
+   * @type {TresRenderer}
    * @memberof TresPartialContext
    */
-  renderer: WebGLRenderer
+  renderer: TresRenderer
   /**
    * The current active camera
    *
@@ -36,8 +37,8 @@ export interface TresPartialContext extends Omit<TresContext, 'renderer' | 'came
   advance: () => void
 }
 
-export function useTres(): TresPartialContext {
-  const { scene, renderer, camera, sizes, controls, loop, extend, events } = useTresContext()
+export async function useTres(): Promise<TresPartialContext> {
+  const { scene, renderer, camera, sizes, controls, loop, extend, events } = await useTresContext()
 
   return {
     scene,

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -12,7 +12,6 @@ import type { UseCameraReturn } from '../useCamera/'
 import { useCameraManager } from '../useCamera'
 import { useRendererManager } from '../useRenderer/useRendererManager'
 import useSizes, { type SizesType } from '../useSizes'
-import type { TresCanvasProps } from '../../components/TresCanvas.vue'
 import { useEventManager } from '../useEventManager'
 
 export interface TresContext {
@@ -35,7 +34,7 @@ export function useTresContextProvider({
   scene: TresScene
   canvas: MaybeRef<HTMLCanvasElement>
   windowSize: MaybeRefOrGetter<boolean>
-  rendererOptions: TresCanvasProps
+  rendererOptions: RendererOptions
 }): TresContext {
   const localScene = shallowRef(scene)
   const sizes = useSizes(windowSize, canvas)
@@ -48,7 +47,7 @@ export function useTresContextProvider({
     {
       scene: localScene,
       canvas,
-      options: rendererOptions as RendererOptions,
+      options: rendererOptions,
       contextParts: { sizes, camera, loop },
     },
   )
@@ -79,7 +78,7 @@ export function useTresContextProvider({
   ctx.loop.setReady(false)
   ctx.loop.start()
 
-  renderer.onReady?.(() => {
+  renderer.onReady(() => {
     ctx.loop.setReady(true)
   })
 

--- a/src/composables/useTresContextProvider/index.ts
+++ b/src/composables/useTresContextProvider/index.ts
@@ -37,7 +37,7 @@ export function useTresContextProvider({
   windowSize: MaybeRefOrGetter<boolean>
   rendererOptions: TresCanvasProps
 }): TresContext {
-  const localScene = shallowRef<TresScene>(scene)
+  const localScene = shallowRef(scene)
   const sizes = useSizes(windowSize, canvas)
 
   const camera = useCameraManager({ sizes })
@@ -46,7 +46,7 @@ export function useTresContextProvider({
 
   const renderer = useRendererManager(
     {
-      scene,
+      scene: localScene,
       canvas,
       options: rendererOptions as RendererOptions,
       contextParts: { sizes, camera, loop },
@@ -79,7 +79,7 @@ export function useTresContextProvider({
   ctx.loop.setReady(false)
   ctx.loop.start()
 
-  renderer.onReady(() => {
+  renderer.onReady?.(() => {
     ctx.loop.setReady(true)
   })
 

--- a/src/devtools/inspectorHandlers.ts
+++ b/src/devtools/inspectorHandlers.ts
@@ -271,7 +271,7 @@ export const inspectorStateHandler = (tres: TresContext, { highlightMesh, prevIn
       }
 
       if (instance.isScene) {
-        payload.state = {
+        const sceneState = {
           ...payload.state,
           state: [
             {
@@ -285,15 +285,19 @@ export const inspectorStateHandler = (tres: TresContext, { highlightMesh, prevIn
                 lines: tres.renderer.instance.info.render.lines,
               },
             },
-            {
-              key: 'Programs',
-              value: tres.renderer.instance.info.programs?.map(program => ({
-                ...program,
-                programName: program.name,
-              })) || [],
-            },
           ],
         }
+
+        if ('programs' in tres.renderer.instance.info) {
+          sceneState.state.push({
+            key: 'Programs',
+            value: tres.renderer.instance.info.programs?.map(program => ({
+              ...program,
+              programName: program.name,
+            })),
+          })
+        }
+        payload.state = sceneState
       }
     }
     else if (payload.nodeId.includes('context')) {


### PR DESCRIPTION
# feat: WebGPU native support

This PR adds native WebGPU support to TresJS, allowing for better performance and modern rendering capabilities. The changes include:

## Key Changes
- Added WebGPU renderer support alongside existing WebGL renderer
- Improved renderer initialization with proper type handling
- Enhanced scene graph inspection capabilities for both WebGL and WebGPU contexts
- Added proper cleanup and context loss handling for both renderers

## Technical Details
- Modified renderer manager to handle both WebGL and WebGPU renderers
- Updated type definitions to support both renderer types
- Improved inspector tools to work with both rendering backends
- Added proper initialization for WebGPU context

## Usage

To enable WebGPU is as simple as: 

```ts
<script setup lang="ts">
const createWebGPURenderer = (ctx: TresRendererSetupContext) => {
  const renderer = new WebGPURenderer({
    canvas: toValue(ctx.canvas),
    // WebGPU specific configuration
    alpha: true,
    antialias: true,
  })
  return renderer
}
</script>

<template>
  <TresCanvas :renderer="createWebGPURenderer">
  </TresCanvas>
</template>
```

## Breaking Changes
None. The changes are backward compatible with existing WebGL implementations.

## Testing
- [ ] Tested with WebGL renderer
- [ ] Tested with WebGPU renderer
- [ ] Verified inspector tools work with both renderers
- [ ] Checked memory management and cleanup

## Related Issues
Closes #883