### PR TITLE
refactor: typed navigation key in docs

### DIFF
--- a/docs/app/components/AppHeader.vue
+++ b/docs/app/components/AppHeader.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { ContentNavigationItem } from '@nuxt/content'
-
-const navigation = inject<Ref<ContentNavigationItem[]>>(navigationInjectionKey)
+const navigation = inject(navigationInjectionKey)
 
 const { header } = useAppConfig()
 

--- a/docs/app/components/AppSide.vue
+++ b/docs/app/components/AppSide.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { ContentNavigationItem } from '@nuxt/content'
-
-const navigation = inject<Ref<ContentNavigationItem[]>>(navigationInjectionKey)
+const navigation = inject(navigationInjectionKey)
 
 const route = useRoute()
 

--- a/docs/app/pages/[...slug].vue
+++ b/docs/app/pages/[...slug].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { ContentNavigationItem } from '@nuxt/content'
 import { findPageHeadline } from '#ui-pro/utils/content'
 
 definePageMeta({
@@ -8,7 +7,7 @@ definePageMeta({
 
 const route = useRoute()
 const { toc } = useAppConfig()
-const navigation = inject<Ref<ContentNavigationItem[]>>(navigationInjectionKey)
+const navigation = inject(navigationInjectionKey)
 
 const { data: page } = await useAsyncData(route.path, () => queryCollection('docs').path(route.path).first())
 if (!page.value) {
@@ -60,7 +59,7 @@ const links = computed(() => {
       :links="page.links"
       :headline="headline"
       :ui="{
-        headline: 'uppercase font-mono font-light text-default-500 text-dim',
+        headline: 'uppercase font-mono font-light text-default-500 text-dim'
       }"
     />
 

--- a/docs/app/utils/content.ts
+++ b/docs/app/utils/content.ts
@@ -1,6 +1,6 @@
 import type { ContentNavigationItem } from '@nuxt/content'
 
-export const navigationInjectionKey = Symbol('navigation')
+export const navigationInjectionKey: InjectionKey<Ref<ContentNavigationItem[] | undefined>> = Symbol('navigation')
 
 export function navPageFromPath(path: string, tree: ContentNavigationItem[]): ContentNavigationItem | undefined {
   for (const file of tree) {


### PR DESCRIPTION
- Removed type annotations from the `inject` function in `AppHeader.vue`, `AppSide.vue`, and `[...slug].vue` for cleaner code.
- Updated the `navigationInjectionKey` export in `content.ts` to include a more specific type definition, enhancing type safety.