### PR TITLE
revert(docs): revert active navigation change

### DIFF
--- a/docs/app/composables/useNavigation.ts
+++ b/docs/app/composables/useNavigation.ts
@@ -9,7 +9,6 @@ export interface HeaderLink {
   children?: HeaderLink[]
 }
 
-
 function _useHeaderLinks() {
   const route = useRoute()
   const headerLinks = computed<HeaderLink[]>(() => {
@@ -20,25 +19,25 @@ function _useHeaderLinks() {
       description: 'Learn how to get started with TresJS to build your 3D first app.',
       icon: 'i-lucide-rocket',
       to: `${to}/getting-started`,
-      active: route.path.startsWith(`${to}/getting-started`)
+      active: route.path.startsWith(`${to}/getting-started`),
     }, {
       label: 'Essentials',
       description: 'Get the key concepts and best practices.',
       icon: 'i-lucide-book-open',
       to: `${to}/essentials`,
-      active: route.path.startsWith(`${to}/essentials`)
+      active: route.path.startsWith(`${to}/essentials`),
     }, {
       label: 'API',
       description: 'Explore the TresJS components, composables, utilities and more.',
       icon: 'i-lucide-code-xml',
       to: `${to}/api`,
-      active: route.path.startsWith(`${to}/api`)
+      active: route.path.startsWith(`${to}/api`),
     }, {
       label: 'Cookbook',
       description: 'Discover and explore official and community examples.',
       icon: 'i-lucide-cooking-pot',
       to: `${to}/cookbook`,
-      active: route.path.startsWith(`${to}/cookbook`)
+      active: route.path.startsWith(`${to}/cookbook`),
     }/*  {      label: 'Community',      description: 'Find answers and support from the community.',      icon: 'i-lucide-messages-square',      to: `${to}/community`,      active: route.path.startsWith(`${to}/community`)    } */]
   })
 

--- a/docs/app/composables/useNavigation.ts
+++ b/docs/app/composables/useNavigation.ts
@@ -9,7 +9,9 @@ export interface HeaderLink {
   children?: HeaderLink[]
 }
 
+
 function _useHeaderLinks() {
+  const route = useRoute()
   const headerLinks = computed<HeaderLink[]>(() => {
     const to = ''
 
@@ -18,21 +20,25 @@ function _useHeaderLinks() {
       description: 'Learn how to get started with TresJS to build your 3D first app.',
       icon: 'i-lucide-rocket',
       to: `${to}/getting-started`,
+      active: route.path.startsWith(`${to}/getting-started`)
     }, {
       label: 'Essentials',
       description: 'Get the key concepts and best practices.',
       icon: 'i-lucide-book-open',
       to: `${to}/essentials`,
+      active: route.path.startsWith(`${to}/essentials`)
     }, {
       label: 'API',
       description: 'Explore the TresJS components, composables, utilities and more.',
       icon: 'i-lucide-code-xml',
       to: `${to}/api`,
+      active: route.path.startsWith(`${to}/api`)
     }, {
       label: 'Cookbook',
       description: 'Discover and explore official and community examples.',
       icon: 'i-lucide-cooking-pot',
       to: `${to}/cookbook`,
+      active: route.path.startsWith(`${to}/cookbook`)
     }/*  {      label: 'Community',      description: 'Find answers and support from the community.',      icon: 'i-lucide-messages-square',      to: `${to}/community`,      active: route.path.startsWith(`${to}/community`)    } */]
   })
 


### PR DESCRIPTION
@Tinoooo found out that the `active` property is necessary for the categories' top menu to detect the state when navigating subpages