### PR TITLE
fix(docs): correct missing quote in <TresMesh> example in "3.your-first-scene.md"

### DIFF
--- a/apps/docs/content/1.getting-started/3.your-first-scene.md
+++ b/apps/docs/content/1.getting-started/3.your-first-scene.md
@@ -192,7 +192,7 @@ onBeforeRender(({ elapsed }) => {
   />
 
   <!-- The Donut -->
-  <TresMesh ref="donutRef" :position="[0, 2, 0]>
+  <TresMesh ref="donutRef" :position="[0, 2, 0]">
     <TresTorusGeometry :args="[1, 0.4, 16, 32]" />
     <TresMeshBasicMaterial color="#ff6b35" />
   </TresMesh>


### PR DESCRIPTION
Fixed a typo in the "apps/docs/content/1.getting-started/3.your-first-scene.md" file.

Before
```
<TresMesh ref="donutRef" :position="[0, 2, 0]>
```

After 
```
<TresMesh ref="donutRef" :position="[0, 2, 0]">
```