### PR TITLE
chore: remove redundant spaces from the envinfo command args

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     id: system-info
     attributes:
       label: System Info
-      description: Output of `npx envinfo --system --npmPackages '{vite,@tresjs/*, three, vue}' --binaries --browsers`
+      description: Output of `npx envinfo --system --npmPackages '{vite,@tresjs/*,three,vue}' --binaries --browsers`
       render: shell
       placeholder: System, Binaries, Browsers
   - type: dropdown


### PR DESCRIPTION
To print three and vue version info correctly