### PR TITLE
fix(docs): fix OrbitControls example to use camera instead of renderer

### DIFF
--- a/apps/docs/content/4.cookbook/1.orbit-controls.md
+++ b/apps/docs/content/4.cookbook/1.orbit-controls.md
@@ -36,7 +36,7 @@ const { camera, renderer } = useTres()
 
 <template>
   <TresOrbitControls
-    v-if="renderer"
+    v-if="camera"
     :args="[camera, renderer?.domElement]"
   />
 </template>


### PR DESCRIPTION
as camera is a ref and maybe undefined which will result page load err