### PR TITLE
fix(leches): fix control value display in Nuxt SSR environments

### DIFF
--- a/apps/playground-nuxt/pages/misc/parent-child/Child.vue
+++ b/apps/playground-nuxt/pages/misc/parent-child/Child.vue
@@ -2,11 +2,36 @@
 import { useControls } from '@tresjs/leches'
 
 const uuid = 'leches-basic-parent-child'
-const { wireframe, number: numberControl, booleanDropdown } = useControls({
+const { color, metalness, roughness, wireframe, number: numberControl, booleanDropdown } = useControls({
   wireframe: false,
   number: 1,
   booleanDropdown: true,
+  color: '#ff0000',
+  metalness: { 
+    value: 0.5,
+    min: 0,
+    max: 1,
+    step: 0.1,
+  },
+  roughness: { 
+    value: 0.5,
+    min: 0,
+    max: 1,
+    step: 0.1,
+  },
 }, { uuid })
+
+watch(color, (value) => {
+  console.log('color', value)
+})
+
+watch(metalness, (value) => {
+  console.log('metalness', value)
+})
+
+watch(roughness, (value) => {
+  console.log('roughness', value)
+})
 </script>
 
 <template>

--- a/packages/leches/src/components/BooleanControl.vue
+++ b/packages/leches/src/components/BooleanControl.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, unref } from 'vue'
 import type { LechesBooleanControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
 
@@ -9,6 +10,8 @@ const props = defineProps<{
 
 const emit = defineEmits(['change'])
 
+const controlValue = computed(() => unref(props.control.value))
+
 function onChange(event: Event) {
   const { target } = event
   emit('change', (target as HTMLInputElement).checked)
@@ -17,7 +20,7 @@ function onChange(event: Event) {
 function onKeydown(event: KeyboardEvent) {
   if (event.code === 'Space' || event.code === 'Enter') {
     event.preventDefault() // Prevent scrolling when space is pressed
-    emit('change', !props.control.value)
+    emit('change', !controlValue.value)
   }
 }
 </script>
@@ -30,7 +33,7 @@ function onKeydown(event: KeyboardEvent) {
     />
     <input
       :id="control.uniqueKey"
-      :checked="control.value"
+      :checked="controlValue"
       class="tl-hidden"
       type="checkbox"
       @input="onChange"
@@ -42,9 +45,9 @@ function onKeydown(event: KeyboardEvent) {
       <span
         tabindex="0"
         role="checkbox"
-        :aria-checked="control.value"
-        :class="{ 'tl-bg-dark-500 dark:tl-bg-gray-400': control.value,
-                  'tl-bg-gray-100 dark:tl-bg-dark-300': !control.value }"
+        :aria-checked="controlValue"
+        :class="{ 'tl-bg-dark-500 dark:tl-bg-gray-400': controlValue,
+                  'tl-bg-gray-100 dark:tl-bg-dark-300': !controlValue }"
         class="tl-w-4
           tl-h-4
           tl-flex
@@ -65,7 +68,7 @@ function onKeydown(event: KeyboardEvent) {
         @keydown="onKeydown"
       >
         <i
-          v-show="control.value"
+          v-show="controlValue"
           class="i-ic:baseline-check tl-text-light dark:tl-text-dark"
         ></i></span>
     </label>

--- a/packages/leches/src/components/ColorControl.vue
+++ b/packages/leches/src/components/ColorControl.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { computed, unref } from 'vue'
 import type { LechesControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
 
-defineProps<{
+const props = defineProps<{
   label: string
   control: LechesControl
 }>()
 
 const emit = defineEmits(['change'])
+
+const controlValue = computed(() => unref(props.control.value))
 
 function onChange(event: Event) {
   const { target } = event
@@ -22,14 +25,14 @@ function onChange(event: Event) {
       <input
         :id="control.uniqueKey"
         tabindex="0"
-        :value="control.value"
+        :value="controlValue"
         :aria-label="label"
         class="leches-color
         focus:tl-outline-none
         focus:tl-ring-2
         focus:tl-ring-gray-100
         "
-        :class="{ 'important-tl-outline-gray-200': control.value === '#ffffff' }"
+        :class="{ 'important-tl-outline-gray-200': controlValue === '#ffffff' }"
         type="color"
         @input="onChange"
       />
@@ -37,7 +40,7 @@ function onChange(event: Event) {
         :id="control.uniqueKey"
         tabindex="0"
         :aria-label="label"
-        :value="control.value"
+        :value="controlValue"
         class="tl-leches-input tl-w-1/2"
         type="text"
         @input="onChange"

--- a/packages/leches/src/components/NumberControl.vue
+++ b/packages/leches/src/components/NumberControl.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, unref, watch } from 'vue'
 import { useMouse } from '@vueuse/core'
 import type { LechesNumberControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
@@ -10,6 +10,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits(['change'])
+
+const controlValue = computed(() => unref(props.control.value))
 
 function onChange(event: Event) {
   const { target } = event
@@ -36,18 +38,19 @@ watch(mouse.x, (newValue) => {
   if (isMouseDown.value) {
     const diff = newValue - initialMouseX.value
     const speed = calculateSpeed(diff)
+    const currentValue = controlValue.value
     if (diff > 0) {
-      emit('change', props.control.value + 1 + speed)
+      emit('change', currentValue + 1 + speed)
     }
     else if (diff < 0) {
-      emit('change', props.control.value - 1 + speed)
+      emit('change', currentValue - 1 + speed)
     }
 
-    if (props.control.min !== undefined && props.control.value < props.control.min) {
+    if (props.control.min !== undefined && currentValue < props.control.min) {
       emit('change', props.control.min)
     }
 
-    if (props.control.max !== undefined && props.control.value > props.control.max) {
+    if (props.control.max !== undefined && currentValue > props.control.max) {
       emit('change', props.control.max)
     }
 
@@ -64,7 +67,7 @@ watch(mouse.x, (newValue) => {
     />
     <input
       :id="control.uniqueKey"
-      :value="control.value"
+      :value="controlValue"
       class="tl-leches-input tl-w-2/3"
       type="number"
       :class="{ 'tl-cursor-ew-resize': isMouseDown }"

--- a/packages/leches/src/components/SelectControl.vue
+++ b/packages/leches/src/components/SelectControl.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, unref } from 'vue'
 import type { LechesControl, LechesSelectOption } from '../types'
 import ControlLabel from './ControlLabel.vue'
 
@@ -8,6 +9,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits(['change'])
+
+const controlValue = computed(() => unref(props.control.value))
 
 function onChange(event: Event) {
   const selectedValue = (event.target as HTMLSelectElement).value
@@ -30,7 +33,7 @@ function onChange(event: Event) {
     />
     <select
       :id="control.uniqueKey"
-      :value="String(control.value)"
+      :value="String(controlValue)"
       class="tl-leches-input tl-w-2/3"
       @change="onChange"
     >

--- a/packages/leches/src/components/SliderControl.vue
+++ b/packages/leches/src/components/SliderControl.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, unref, watch } from 'vue'
 import { useDark, useMouse } from '@vueuse/core'
 import type { LechesNumberControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
@@ -10,6 +10,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits(['change'])
+
+const controlValue = computed(() => unref(props.control.value))
 
 function onChange(event: Event) {
   const { target } = event
@@ -23,7 +25,7 @@ const sliderFilledStyle = computed(() => {
   const colorEnd = isDark.value ? '#2d2d2d' : '#9ca3af'
   return {
     backgroundImage: `linear-gradient(to right, ${colorStart} 0% ${
-      (100 * ((props.control.value as number) - (props.control.min || 0)))
+      (100 * ((controlValue.value as number) - (props.control.min || 0)))
       / ((props.control.max || 100) - (props.control.min || 0))
     }%, ${colorEnd} 0%)`,
   }
@@ -48,18 +50,19 @@ watch(mouse.x, (newValue) => {
   if (isMouseDown.value) {
     const diff = newValue - initialMouseX.value
     const speed = calculateSpeed(diff)
+    const currentValue = controlValue.value
     if (diff > 0) {
-      emit('change', props.control.value + 1 + speed)
+      emit('change', currentValue + 1 + speed)
     }
     else if (diff < 0) {
-      emit('change', props.control.value - 1 + speed)
+      emit('change', currentValue - 1 + speed)
     }
 
-    if (props.control.min !== undefined && props.control.value < props.control.min) {
+    if (props.control.min !== undefined && currentValue < props.control.min) {
       emit('change', props.control.min)
     }
 
-    if (props.control.max !== undefined && props.control.value > props.control.max) {
+    if (props.control.max !== undefined && currentValue > props.control.max) {
       emit('change', props.control.max)
     }
 
@@ -76,7 +79,7 @@ watch(mouse.x, (newValue) => {
     />
     <div class="tl-relative tl-w-2/3 tl-flex tl-justify-between tl-items-center tl-gap-0.5">
       <input
-        :value="control.value"
+        :value="controlValue"
         class="leches-range tl-w-1/2 tl-h-0.75 tl-bg-dark-200 dark:tl-bg-yellow tl-rounded-full tl-appearance-none"
         :style="sliderFilledStyle"
         type="range"
@@ -86,7 +89,7 @@ watch(mouse.x, (newValue) => {
         @input="onChange"
       />
       <input
-        :value="control.value"
+        :value="controlValue"
         class="tl-leches-input tl-w-1/4"
         :class="{ 'tl-cursor-ew-resize': isMouseDown }"
         type="number"

--- a/packages/leches/src/components/TextControl.vue
+++ b/packages/leches/src/components/TextControl.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { computed, unref } from 'vue'
 import type { LechesControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
 
-defineProps<{
+const props = defineProps<{
   label: string
   control: LechesControl
 }>()
 
 const emit = defineEmits(['change'])
+
+const controlValue = computed(() => unref(props.control.value))
 
 function onChange(event: Event) {
   const { target } = event
@@ -23,7 +26,7 @@ function onChange(event: Event) {
     />
     <input
       :id="control.uniqueKey"
-      :value="control.value"
+      :value="controlValue"
       type="text"
       tabindex="0"
       class="tl-leches-input tl-w-2/3"

--- a/packages/leches/src/components/TresLeches.vue
+++ b/packages/leches/src/components/TresLeches.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
+import { computed, isRef, nextTick, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
 import { useDraggable } from '../composables/useDraggable'
 import { useWindowSize } from '@vueuse/core'
 import { dispose, useControlsProvider, useControlsStore } from '../composables/useControls'
@@ -56,7 +56,14 @@ const { store: controlsStore, triggers: controlsTriggers } = useControlsStore()
 defineExpose(controls)
 
 function onChange(key: string, value: string) {
-  controls[key].value = value
+  const control = controls[key] as any
+  // Update the ref (control.value is a ref)
+  if (isRef(control.value)) {
+    control.value.value = value
+  }
+  else {
+    control.value = value
+  }
 }
 
 const groupedControls = computed(() => {

--- a/packages/leches/src/components/VectorControl.vue
+++ b/packages/leches/src/components/VectorControl.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useKeyModifier, useMouse, useMousePressed } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, unref, watch } from 'vue'
 import { isVector2, isVector3, normalizeVectorFlexibleParam } from '../utils/'
 import type { LechesVectorControl } from '../types'
 import ControlLabel from './ControlLabel.vue'
@@ -62,13 +62,14 @@ watch(pressed, (newValue) => {
 
 const calculateSpeed = (diff: number) => Math.floor(Math.abs(diff) / 10)
 
-const vector = computed(() => normalizeVectorFlexibleParam(props.control.value))
+const controlValue = computed(() => unref(props.control.value))
+const vector = computed(() => normalizeVectorFlexibleParam(controlValue.value))
 const labels = ref(['x', 'y', 'z'])
 
-const isVector = computed(() => isVector2(props.control.value) || isVector3(props.control.value))
+const isVector = computed(() => isVector2(controlValue.value) || isVector3(controlValue.value))
 
 function onChange(event: Event, $index: number) {
-  const { value } = props.control
+  const value = controlValue.value
   const { target } = event
   index.value = $index
 
@@ -80,7 +81,7 @@ watch(mouse.x, (newValue) => {
   if (isMouseDown.value) {
     const diff = newValue - initialMouseX.value
     const speed = calculateSpeed(diff)
-    const { value } = props.control
+    const value = controlValue.value
     const label = isVector.value ? labels.value[index.value] : index.value
 
     if (diff > 0) {
@@ -121,8 +122,8 @@ watch(mouse.x, (newValue) => {
         class="tl-flex tl-items-center tl-bg-gray-100 dark:tl-bg-dark-300 tl-rounded tl-border-none tl-outline-none tl-focus:tl-border-gray-200 tl-focus:tl-ring tl-focus:tl-ring-gray-200"
         :class="{
           'tl-w-2/5': focused === $index,
-          'tl-w-1/3': isVector3(control.value),
-          'tl-w-1/2': isVector2(control.value),
+          'tl-w-1/3': isVector3(controlValue),
+          'tl-w-1/2': isVector2(controlValue),
         }"
       >
         <span


### PR DESCRIPTION
## Problem

  TresLeches controls displayed `[object Object]` instead of actual values in Nuxt applications. This only occurred in SSR environments, not in regular Vue apps.

  ## Root Cause

  Vue's automatic ref unwrapping doesn't work consistently for nested refs (`control.value` containing a Ref) during Nuxt's SSR hydration process. The control components were binding directly to `control.value`, which Vue couldn't reliably unwrap in the SSR context.

  ## Solution

  - Added explicit `unref()` calls in all control components via computed properties
  - Updated `TresLeches` onChange handler to properly mutate ref values
  - Ensures consistent behavior across SSR and client-only contexts

  ## Changes

  - Modified control components: Boolean, Color, Number, Select, Slider, Text, Vector
  - Updated TresLeches onChange to handle ref updates correctly
  - No breaking changes - maintains backward compatibility