### PR TITLE
feat(core): export `Context` component

### DIFF
--- a/apps/docs/content/3.api/1.components/tres-context.md
+++ b/apps/docs/content/3.api/1.components/tres-context.md
@@ -1,11 +1,11 @@
 ---
-title: <TresContext />
+title: <TresCanvasContext />
 description: Internal context component used by TresCanvas for advanced setups.
 ---
 
 ## Component Overview
 
-`<TresContext />` is the internal component that powers `<TresCanvas />`. It mounts the TresJS renderer and scene using a **provided canvas element** instead of creating one for you.
+`<TresCanvasContext />` is the internal component that powers `<TresCanvas />`. It mounts the TresJS renderer and scene using a **provided canvas element** instead of creating one for you.
 
 ::note
 This component is exported for advanced use cases only. In most apps you should keep using `<TresCanvas />`.
@@ -13,24 +13,24 @@ This component is exported for advanced use cases only. In most apps you should 
 
 ## When to Use It
 
-Use `<TresContext />` only if you already own the WebGL canvas (or must integrate with a host framework that provides one) and you still want TresJS to manage the Three.js scene, render loop, and events.
+Use `<TresCanvasContext />` only if you already own the WebGL canvas (or must integrate with a host framework that provides one) and you still want TresJS to manage the Three.js scene, render loop, and events.
 
 ## Usage
 
 ```vue [app.vue]
 <script setup lang="ts">
 import { ref } from 'vue'
-import { TresContext } from '@tresjs/core'
+import { TresCanvasContext } from '@tresjs/core'
 
 const canvasRef = ref<HTMLCanvasElement>()
 </script>
 
 <template>
   <canvas ref="canvasRef" class="w-full h-full">
-    <TresContext v-if="canvasRef" :canvas="canvasRef">
+    <TresCanvasContext v-if="canvasRef" :canvas="canvasRef">
       <TresPerspectiveCamera :position="[3, 3, 3]" />
       <!-- Your scene content here -->
-    </TresContext>
+    </TresCanvasContext>
   </canvas>
 </template>
 ```

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,5 +1,5 @@
 import TresCanvas from './TresCanvas.vue'
 import Context from './Context.vue'
 
-export { Context as TresContext, TresCanvas }
+export { Context as TresCanvasContext, TresCanvas }
 export type { TresCanvasEmits, TresCanvasInstance, TresCanvasProps } from './TresCanvas.vue'

--- a/packages/core/src/utils/template-compiler-options.ts
+++ b/packages/core/src/utils/template-compiler-options.ts
@@ -1,6 +1,6 @@
 const whitelist = [
   'TresCanvas',
-  'TresContext',
+  'TresCanvasContext',
   'TresLeches',
   'TresScene',
 ]


### PR DESCRIPTION
close: #1233
close: #1210

reference: https://github.com/Tresjs/tres/pull/1233#discussion_r2649561876

Export Context component to reuse its logic for host-provided WebGL without creating a new canvas instance.