### PR TITLE
fix(cientos): apply BVH immediately when target is already available

### DIFF
--- a/packages/cientos/src/core/performance/useBVH.ts
+++ b/packages/cientos/src/core/performance/useBVH.ts
@@ -265,7 +265,7 @@ export const useBVH = (
     if (objectValue && toValue(enabled)) {
       applyBVH(objectValue)
     }
-  })
+  }, { immediate: true })
 
   watch(() => toValue(enabled), (enabled) => {
     if (enabled) {


### PR DESCRIPTION
## Summary

- Add `{ immediate: true }` to the `whenever` call in `useBVH` so BVH optimization is applied when the target is already truthy at call time

## Problem

`useBVH` silently failed when assets were preloaded or cached. Without `immediate: true`, Vue's `watch` only fires on transitions (null → Object3D), so if the target ref was already populated at mount time, `applyBVH` was never called.

## Test plan

- [ ] Verify BVH is applied when target is a pre-existing (non-null) ref
- [ ] Verify BVH still applies when target transitions from null → Object3D (async load)
- [ ] Verify `enabled: false` still prevents BVH application in both cases

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)