### PR TITLE
docs(postprocessing): migrate new three effects to Nuxt docs + retarget docs-writer agent

### DIFF
--- a/apps/postprocessing-docs/app/components/three/Afterimage.vue
+++ b/apps/postprocessing-docs/app/components/three/Afterimage.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { Afterimage, EffectComposer } from '@tresjs/post-processing'
+import { Color } from 'three'
+
+const gl = {
+  clearColor: '#121212',
+  shadows: true,
+  alpha: false,
+}
+
+const emissiveColor = new Color('cyan')
+</script>
+
+<template>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[3, 4, 4]" />
+    <OrbitControls
+      auto-rotate
+      :auto-rotate-speed="2"
+      :target="[0, 1, 0]"
+    />
+    <TresMesh :position="[0, 1, 0]">
+      <TresTorusKnotGeometry :args="[0.8, 0.3, 128, 32]" />
+      <TresMeshStandardMaterial
+        color="cyan"
+        :emissive="emissiveColor"
+        :emissive-intensity="0.2"
+      />
+    </TresMesh>
+
+    <TresGridHelper />
+    <TresAmbientLight :intensity="1" />
+    <TresDirectionalLight
+      :position="[3, 5, 3]"
+      :intensity="1.5"
+    />
+
+    <EffectComposer>
+      <Afterimage :damp="0.98" />
+    </EffectComposer>
+  </TresCanvas>
+</template>

--- a/apps/postprocessing-docs/app/components/three/Film.vue
+++ b/apps/postprocessing-docs/app/components/three/Film.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { OrbitControls } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { EffectComposer, Film } from '@tresjs/post-processing'
+
+const gl = {
+  clearColor: '#121212',
+  shadows: true,
+  alpha: false,
+}
+</script>
+
+<template>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera
+      :position="[3, 2, 4]"
+      :look-at="[0, 0, 0]"
+    />
+    <OrbitControls />
+    <TresMesh :position="[-1, 0.5, 0]">
+      <TresSphereGeometry :args="[0.8, 32, 32]" />
+      <TresMeshStandardMaterial color="#f0f0f0" />
+    </TresMesh>
+    <TresMesh :position="[1.2, 0.5, 0]">
+      <TresTorusGeometry :args="[0.5, 0.2, 16, 32]" />
+      <TresMeshStandardMaterial color="aqua" />
+    </TresMesh>
+
+    <TresGridHelper />
+    <TresAmbientLight :intensity="0.8" />
+    <TresDirectionalLight
+      :position="[-5, 5, 5]"
+      :intensity="1.5"
+    />
+
+    <EffectComposer>
+      <Film :intensity="1" />
+    </EffectComposer>
+  </TresCanvas>
+</template>

--- a/apps/postprocessing-docs/app/components/three/Sao.vue
+++ b/apps/postprocessing-docs/app/components/three/Sao.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { EffectComposer, Output, SAO } from '@tresjs/post-processing'
+import { ref } from 'vue'
+
+const rotationY = ref(0)
+const rotate = ({ elapsed }: { elapsed: number }) => {
+  rotationY.value = elapsed * 0.15
+}
+
+const spheres = Array.from({ length: 40 }, () => ({
+  position: [
+    Math.random() * 4 - 2,
+    Math.random() * 4 - 2,
+    Math.random() * 4 - 2,
+  ] as [number, number, number],
+  scale: Math.random() * 0.35 + 0.08,
+  color: `hsl(${Math.random() * 360}, 70%, 35%)`,
+}))
+
+const sides = [
+  { css: 'doc-sao-canvas-left', effect: false, label: '⬅️ No SAO', labelCss: 'doc-sao-info-left' },
+  { css: 'doc-sao-canvas-right', effect: true, label: 'With SAO ➡️', labelCss: 'doc-sao-info-right' },
+]
+</script>
+
+<template>
+  <div class="relative h-full w-full">
+    <template v-for="side in sides" :key="side.css">
+      <TresCanvas
+        clear-color="#121212"
+        :alpha="false"
+        render-mode="always"
+        :class="side.css"
+        @loop="rotate"
+      >
+        <TresPerspectiveCamera
+          :position="[0, 0, 7]"
+          :look-at="[0, 0, 0]"
+          :fov="65"
+          :near="3"
+          :far="10"
+        />
+
+        <TresAmbientLight :intensity="0.2" />
+        <TresPointLight color="#efffef" :intensity="900" :position="[-10, -10, 10]" />
+        <TresPointLight color="#ffefef" :intensity="900" :position="[-10, 10, 10]" />
+        <TresPointLight color="#efefff" :intensity="900" :position="[10, -10, 10]" />
+
+        <TresGroup :rotation-y="rotationY">
+          <TresMesh
+            v-for="(s, i) in spheres"
+            :key="i"
+            :position="s.position"
+            :scale="[s.scale, s.scale, s.scale]"
+          >
+            <TresSphereGeometry :args="[3, 32, 16]" />
+            <TresMeshStandardMaterial :color="s.color" :roughness="0.7" :metalness="0" />
+          </TresMesh>
+        </TresGroup>
+
+        <EffectComposer v-if="side.effect">
+          <SAO
+            :sao-intensity="0.18"
+            :sao-scale="1"
+            :sao-kernel-radius="100"
+            :sao-blur="true"
+            :sao-blur-radius="8"
+            :sao-blur-std-dev="4"
+          />
+          <Output />
+        </EffectComposer>
+      </TresCanvas>
+
+      <p class="doc-sao-info text-xs font-semibold" :class="side.labelCss">{{ side.label }}</p>
+    </template>
+
+    <div class="doc-sao-divider"></div>
+  </div>
+</template>
+
+<style scoped>
+.doc-sao-canvas-left {
+  position: absolute !important;
+  inset: 0;
+  z-index: 1;
+  clip-path: inset(0 50% 0 0);
+  -webkit-clip-path: inset(0 50% 0 0);
+}
+
+.doc-sao-canvas-right {
+  position: absolute !important;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  clip-path: inset(0 0 0 50%);
+  -webkit-clip-path: inset(0 0 0 50%);
+}
+
+.doc-sao-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  background: red;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.doc-sao-info {
+  position: absolute;
+  bottom: 0;
+  padding: 0.45rem 0.75rem;
+  margin: 0;
+  text-align: center;
+  color: #fff;
+  z-index: 2;
+  background: linear-gradient(90deg, #7a95b1 0%, #517284 100%);
+}
+
+.doc-sao-info-left {
+  left: 0;
+  border-radius: 0px 10px 0px 0px;
+}
+
+.doc-sao-info-right {
+  right: 0;
+  border-radius: 10px 0px 0px 0px;
+}
+</style>

--- a/apps/postprocessing-docs/content/2.api/2.three/afterimage.md
+++ b/apps/postprocessing-docs/content/2.api/2.three/afterimage.md
@@ -1,0 +1,47 @@
+---
+title: Afterimage
+description: Persistent motion trails by blending previous frames with the current one.
+---
+
+::DocsDemo{:controls="false"}
+  ::ThreeAfterimage
+  ::
+::
+
+Afterimage is an effect that creates persistent motion trails by blending previous frames with the current one. It produces a ghostly trailing effect where objects leave behind fading echoes as they move, similar to long-exposure photography.
+
+The `<Afterimage />` component wraps the Three.js `AfterimagePass` and provides a configurable `damp` property to control the intensity and duration of the trails.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Afterimage, EffectComposer } from '@tresjs/post-processing'
+</script>
+
+<template>
+  <TresCanvas>
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposer>
+        <Afterimage :damp="0.96" />
+      </EffectComposer>
+    </Suspense>
+  </TresCanvas>
+</template>
+```
+
+## Props
+
+| Prop             | Description                                                                                      | Default |
+| ---------------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `damp`           | Damping intensity from 0.0 to 1.0. Higher values produce stronger, longer-lasting motion trails. | `0.96`  |
+| `enabled`        | If set to true, the pass is processed by the composer.                                           | `true`  |
+| `needsSwap`      | If set to true, the pass indicates to swap read and write buffer after rendering.                | `true`  |
+| `clear`          | If set to true, the pass clears its buffer before rendering.                                     | `false` |
+| `renderToScreen` | If set to true, the result of the pass is rendered to screen.                                    | `false` |
+
+## Further Reading
+
+See the [Three.js example](https://threejs.org/examples/?q=afterimage#webgl_postprocessing_afterimage).

--- a/apps/postprocessing-docs/content/2.api/2.three/film.md
+++ b/apps/postprocessing-docs/content/2.api/2.three/film.md
@@ -1,0 +1,48 @@
+---
+title: Film
+description: Classic cinema film look with film grain noise and optional grayscale.
+---
+
+::DocsDemo{:controls="false"}
+  ::ThreeFilm
+  ::
+::
+
+Film is an effect that simulates the look of classic cinema film, adding film grain noise to your 3D scenes. This effect can give your renders a vintage, cinematic aesthetic reminiscent of analog film recordings.
+
+The `<Film />` component allows you to add film grain to your scenes with adjustable intensity. You can also enable grayscale mode to create a black-and-white film look, perfect for dramatic or nostalgic visual styles.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { EffectComposer, Film } from '@tresjs/post-processing'
+</script>
+
+<template>
+  <TresCanvas>
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposer>
+        <Film :intensity="0.5" :grayscale="false" />
+      </EffectComposer>
+    </Suspense>
+  </TresCanvas>
+</template>
+```
+
+## Props
+
+| Prop             | Description                                                                | Default |
+| ---------------- | -------------------------------------------------------------------------- | ------- |
+| `intensity`      | The grain intensity in the range [0, 1] (0 = no effect, 1 = full effect).  | `0.5`   |
+| `grayscale`      | Whether to apply a grayscale effect.                                       | `false` |
+| `enabled`        | If set to true, the pass is processed by the composer.                     | `true`  |
+| `needsSwap`      | If set to true, the pass indicates to swap read and write buffer after rendering. | `true`  |
+| `clear`          | If set to true, the pass clears its buffer before rendering.               | `false` |
+| `renderToScreen` | If set to true, the result of the pass is rendered to screen.              | `false` |
+
+## Further Reading
+
+See the [Three.js example](https://threejs.org/examples/?q=film#webgl_postprocessing).

--- a/apps/postprocessing-docs/content/2.api/2.three/sao.md
+++ b/apps/postprocessing-docs/content/2.api/2.three/sao.md
@@ -1,0 +1,50 @@
+---
+title: SAO
+description: Scalable Ambient Occlusion for soft, contact-like shadows.
+---
+
+::DocsDemo{:controls="false"}
+  ::ThreeSao
+  ::
+::
+
+SAO (Scalable Ambient Occlusion) adds realistic ambient occlusion to the scene by darkening areas where surfaces are close together, such as corners and crevices. It produces soft, contact-like shadows that enhance depth perception.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { EffectComposer, SAO } from '@tresjs/post-processing'
+</script>
+
+<template>
+  <TresCanvas>
+    <!-- Your scene -->
+
+    <Suspense>
+      <EffectComposer>
+        <SAO :sao-intensity="0.005" :sao-scale="5" />
+      </EffectComposer>
+    </Suspense>
+  </TresCanvas>
+</template>
+```
+
+## Props
+
+| Prop                 | Description                                                              | Default  |
+| -------------------- | ------------------------------------------------------------------------ | -------- |
+| `output`             | Visualization mode. `0` = composited AO, `1` = raw AO texture, `2` = normal buffer. | `0`      |
+| `saoBias`            | Bias for the AO calculation. Higher values reduce self-occlusion artifacts. | `0.5`    |
+| `saoIntensity`       | Intensity of the ambient occlusion effect.                               | `0.0025` |
+| `saoScale`           | Scale factor for the AO distance-dependent falloff.                      | `1`      |
+| `saoKernelRadius`    | Radius of the AO sampling kernel in world-space units.                   | `100`    |
+| `saoMinResolution`   | Minimum resolution threshold for AO samples.                             | `0`      |
+| `saoBlur`            | Whether to apply a depth-limited blur to reduce noise.                   | `true`   |
+| `saoBlurRadius`      | Kernel radius for the depth-limited Gaussian blur.                       | `8`      |
+| `saoBlurStdDev`      | Standard deviation of the Gaussian blur kernel.                          | `4`      |
+| `saoBlurDepthCutoff` | Depth cutoff factor for the blur to prevent blurring across edges.       | `0.01`   |
+
+## Further Reading
+
+See the [Three.js example](https://threejs.org/examples/?q=sao#webgl_postprocessing_sao).

--- a/packages/postprocessing/.claude/agents/docs-writer.md
+++ b/packages/postprocessing/.claude/agents/docs-writer.md
@@ -21,22 +21,37 @@ This classification determines the folder structure and documentation patterns.
 
 ### Step 1: Create Markdown Documentation
 
-**File Location:**
-- pmndrs effects: `../../apps/postprocessing-docs-vitepress/guide/pmndrs/`
-- Three.js effects: `../../apps/postprocessing-docs-vitepress/guide/three/`
+The docs site is a **Nuxt + Nuxt UI + Nuxt Content** app at `../../apps/postprocessing-docs/`. Pages are Markdown with **MDC** (Markdown Components) syntax — NOT VitePress.
+
+**File Location** (kebab-case filename, e.g. `chromatic-aberration.md`):
+- pmndrs effects: `../../apps/postprocessing-docs/content/2.api/1.pmndrs/`
+- Three.js effects: `../../apps/postprocessing-docs/content/2.api/2.three/`
 
 **Required Sections:**
 
-1. **Title and Introduction**: Brief description of what the effect does
-
-2. **Demo**: Embed the demo component you'll create in Step 2
+0. **Frontmatter** (required — drives the page title, SEO, and search):
    ```md
-   <DocsDemo>
-     <ComponentNameDemo />
-   </DocsDemo>
+   ---
+   title: Effect Name
+   description: One-line summary of what the effect does.
+   ---
    ```
 
-3. **Usage**: Concise code snippet showing component usage
+1. **Introduction**: Brief description of what the effect does (after the demo)
+
+2. **Demo**: Embed the demo component you'll create in Step 2 using MDC syntax. The
+   component is auto-imported by directory prefix: `app/components/pmndrs/Bloom.vue`
+   → `::PmndrsBloom`, `app/components/three/Smaa.vue` → `::ThreeSmaa`.
+   ```md
+   ::DocsDemo
+     ::PmndrsBloom
+     ::
+   ::
+   ```
+   - If the demo has **no** Leches controls, disable the panel: `::DocsDemo{:controls="false"}`
+   - If the demo **has** Leches controls (the common case for pmndrs), omit the prop (defaults to `true`).
+
+3. **Usage**: Concise code snippet showing component usage, wrapped in `<TresCanvas>` + `<Suspense>`
    - For pmndrs effects: Use `EffectComposerPmndrs` wrapper
    - For Three.js effects: Use `EffectComposer` wrapper
    - Include necessary imports and basic props
@@ -49,13 +64,38 @@ This classification determines the folder structure and documentation patterns.
    - pmndrs: Link to pmndrs/postprocessing docs
    - Three.js: Link to Three.js examples/documentation
 
-**Reference existing documentation files in the same folder for style and structure consistency.**
+**Reference existing pages in the same folder (e.g. `bloom.md`, `smaa.md`) for style and structure consistency.**
 
 ### Step 2: Create Demo Component
 
-**File Location:**
-- pmndrs effects: `../../apps/postprocessing-docs-vitepress/.vitepress/theme/components/pmndrs/`
-- Three.js effects: `../../apps/postprocessing-docs-vitepress/.vitepress/theme/components/three/`
+**File Location** (PascalCase filename matching the effect name — NO `Demo` suffix, e.g. `ChromaticAberration.vue`):
+- pmndrs effects: `../../apps/postprocessing-docs/app/components/pmndrs/`
+- Three.js effects: `../../apps/postprocessing-docs/app/components/three/`
+
+Components are auto-imported by Nuxt with their directory as prefix, so `pmndrs/Bloom.vue`
+is referenced in Markdown as `::PmndrsBloom` and `three/Smaa.vue` as `::ThreeSmaa`.
+
+**Nuxt conventions (differ from the old VitePress demos):**
+- Do **NOT** use `useRouteDisposal` or a `ref="effectComposer"` — Nuxt unmounts components
+  cleanly on route change, so no manual composer disposal is needed.
+- Do **NOT** wrap the scene in `<Suspense>` or `<ClientOnly>` — the shared `DocsDemo.vue`
+  wrapper already provides both plus the `aspect-video` container.
+- Use a `const gl = { clearColor: '#121212', shadows: true, alpha: false }` object bound via
+  `<TresCanvas v-bind="gl">`, matching existing demos.
+- **Leches controls** (so users can tweak props live): `inject<string>('uuid')` the uuid
+  provided by `DocsDemo`, build refs with `useControls(..., { uuid })`, then bind each ref to
+  the effect **per-prop** (`:intensity="intensity"`) — never `v-bind="reactiveObject"`.
+  ```vue
+  <script setup lang="ts">
+  import { useControls } from '@tresjs/leches'
+
+  const uuid = inject<string>('uuid')
+  const { intensity, radius } = useControls({
+    intensity: { value: 8, min: 0, max: 20, step: 0.1 },
+    radius: { value: 0.5, min: 0, max: 1, step: 0.01 },
+  }, { uuid })
+  </script>
+  ```
 
 **Process:**
 
@@ -79,15 +119,15 @@ This classification determines the folder structure and documentation patterns.
    - Include proper TresCanvas setup
    - Apply consistent styling with existing demos
 
-### Step 3: Register in Sidebar Config
+### Step 3: Sidebar Navigation (no manual edit)
 
-**File:** `../../apps/postprocessing-docs-vitepress/.vitepress/config.ts`
+The sidebar is **auto-generated** from the content directory by Nuxt Content — there is no
+`config.ts` sidebar array to edit. Simply placing the Markdown file in the correct
+`content/2.api/{1.pmndrs|2.three}/` folder is enough; the page appears automatically.
 
-Add the new documentation entry to the correct sidebar section:
-- **pmndrs effects**: Add to the `Pmndrs` sidebar group's `items` array
-- **Three.js effects**: Add to the `Three` sidebar group's `items` array
-
-Entry format: `{ text: 'Effect Name', link: '/guide/{pmndrs|three}/kebab-case-name' }`
+Pages within a folder are ordered alphabetically by filename. If a specific order is needed,
+prefix the filename with a number (e.g. `1.bloom.md`) following the pattern of the parent
+numbered directories.
 
 
 ## Quality Standards


### PR DESCRIPTION
## Summary

Migrates the work this branch added to the **old VitePress** post-processing docs over to the **new Nuxt + Nuxt UI** app (`apps/postprocessing-docs`, merged in #1406), and retargets the docs-writer custom agent so future effects are documented in the new app.

Targets `feat/1334-creation-of-effect-pass-components-via-custom-agents`.

### Docs migration — 3 three-native effects

Ported from `apps/postprocessing-docs-vitepress` → `apps/postprocessing-docs`:

- **Demo components** (`app/components/three/`): `Afterimage.vue`, `Film.vue`, `Sao.vue`
  - Adapted to the Nuxt pattern: `gl` object, no `useRouteDisposal`/`effectComposer` ref (Nuxt unmounts cleanly), `Suspense`/`ClientOnly` provided by `DocsDemo`
  - `Sao.vue` keeps the split-screen (No SAO / With SAO) comparison with scoped CSS
- **Content pages** (`content/2.api/2.three/`): `afterimage.md`, `film.md`, `sao.md` in MDC format with frontmatter
- Sidebar nav is auto-generated from Content — no manual nav edits

### Agent retarget — `docs-writer`

`packages/postprocessing/.claude/agents/docs-writer.md` now emits docs into the new app:
- Markdown → `content/2.api/{1.pmndrs,2.three}/` with frontmatter + MDC `::DocsDemo`/`::Pmndrs*`/`::Three*`
- Demos → `app/components/{pmndrs,three}/` as PascalCase (no `Demo` suffix), auto-imported by directory prefix
- Documents Nuxt conventions: `DocsDemo` provides `ClientOnly`/`Suspense`, Leches via injected `uuid` + per-prop binding
- Drops the VitePress sidebar-config step (nav auto-generated)

## Test plan

- [x] `pnpm --filter postprocessing-docs lint` — clean
- [x] `pnpm --filter postprocessing-docs typecheck` — clean (after rebuilding `@tresjs/post-processing` dist so the new effects' types resolve)
- [x] `pnpm --filter postprocessing-docs build` — all pages prerender, including `/api/three/{afterimage,film,sao}`