### PR TITLE
fix(ci): resolve sponsorkit module error in sponsors scheduler

### DIFF
--- a/.github/actions/cache-monorepo/action.yaml
+++ b/.github/actions/cache-monorepo/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache Nx cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .nx/cache
         key: ${{ runner.os }}-nx-cache-${{ github.sha }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -6,10 +6,10 @@ runs:
     - uses: ./.github/actions/cache-monorepo
 
     - name: Install pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
     
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
         cache: 'pnpm'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "nx run-many --target=typecheck",
     "test": "nx run-many --target=test",
     "monocubo": "node tools/monocubo/dist/index.js",
-    "sponsorkit": "npx sponsorkit",
+    "sponsorkit": "sponsorkit",
     "release": "nx release --skip-publish --group=core",
     "release:version": "nx release version",
     "release:dry-run": "nx release --dry-run --skip-publish --group=core"
@@ -40,7 +40,8 @@
   "devDependencies": {
     "@nx/js": "^22.4.4",
     "@shikijs/engine-javascript": "^3.20.0",
-    "nx": "22.4.4"
+    "nx": "22.4.4",
+    "sponsorkit": "^17.1.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       nx:
         specifier: 22.4.4
         version: 22.4.4
+      sponsorkit:
+        specifier: ^17.1.1
+        version: 17.1.1
 
   apps/cientos-docs:
     dependencies:
@@ -6066,6 +6069,10 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
+  ansis@4.3.0:
+    resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
+    engines: {node: '>=14'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -6353,6 +6360,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -6947,6 +6958,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   draco3d@1.5.7:
@@ -10441,6 +10456,10 @@ packages:
     resolution: {integrity: sha512-K+WKxWdqtKShV33gPjQl769wHxB3glypTOReCvYu/AJd38J+abHlpiF8rK6uBNPMrgw5thHZCI5JkEwsAqa9XA==}
     peerDependencies:
       vue: ^3.2.0
+
+  sponsorkit@17.1.1:
+    resolution: {integrity: sha512-qsDA8ggyJSVszmaDa9aXJFp6DXu8ucK1kA2LRhxijpKcmRA9ndDcQZd8j9RfnLto49Q3SuAsH0L+8QStaZhwzw==}
+    hasBin: true
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -15673,7 +15692,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.1.1
       nx: 22.4.4
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
@@ -15751,7 +15770,7 @@ snapshots:
       enquirer: 2.3.6
       nx: 22.4.4
       picomatch: 4.0.2
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -17403,7 +17422,7 @@ snapshots:
   '@unocss/config@66.5.11':
     dependencies:
       '@unocss/core': 66.5.11
-      unconfig: 7.4.2
+      unconfig: 7.5.0
 
   '@unocss/config@66.6.7':
     dependencies:
@@ -18673,6 +18692,8 @@ snapshots:
 
   ansis@4.2.0: {}
 
+  ansis@4.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -18995,6 +19016,8 @@ snapshots:
       magicast: 0.5.1
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -19546,6 +19569,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
+
+  dotenv@17.4.2: {}
 
   draco3d@1.5.7: {}
 
@@ -21770,7 +21795,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   markdown-it@14.1.0:
     dependencies:
@@ -22408,7 +22433,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   node-addon-api@7.1.1: {}
 
@@ -24521,6 +24546,16 @@ snapshots:
   splitpanes@3.2.0(vue@3.5.26(typescript@5.8.3)):
     dependencies:
       vue: 3.5.26(typescript@5.8.3)
+
+  sponsorkit@17.1.1:
+    dependencies:
+      ansis: 4.3.0
+      cac: 7.0.0
+      consola: 3.4.2
+      dotenv: 17.4.2
+      ofetch: 1.5.1
+      sharp: 0.34.5
+      unconfig: 7.5.0
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
## Summary
- Fixes the failing `update-sponsors` scheduler job: `sponsorkit.config.ts` imports from `'sponsorkit'`, but the package was only fetched ad-hoc via `npx` (npm cache), never installed in `node_modules` — causing `Error: Cannot find module 'sponsorkit'`
- Add `sponsorkit@^17.1.1` as devDependency and run the local bin directly (`pnpm run sponsorkit`)
- Bump composite-action deps to Node 24 runtimes (Node 20 actions deprecated, forced to Node 24 on June 16, 2026):
  - `pnpm/action-setup` v4.3.0 → v6.0.8
  - `actions/setup-node` v4.4.0 → v6.4.0
  - `actions/cache` v4.3.0 → v5.0.5

## Test plan
- [ ] CI green (composite `setup-node`/`cache-monorepo` actions are shared by all workflows)
- [ ] After merge, trigger `Scheduler` workflow via `workflow_dispatch` and confirm `pnpm run sponsorkit` succeeds