### PR TITLE
chore(rapier): prepare @tresjs/rapier for 1.0.0-alpha.0 release

### DIFF
--- a/apps/rapier-docs/content/1.getting-started/1.index.md
+++ b/apps/rapier-docs/content/1.getting-started/1.index.md
@@ -5,6 +5,10 @@ description: Learn how to get started with Rapier
 
  A Vue-first wrapper around [Rapier](https://rapier.rs/) — a fast, robust physics engine written in Rust. It uses the official JavaScript bindings [@dimforge/rapier3d](https://www.npmjs.com/package/@dimforge/rapier3d) compiled to WASM, providing a declarative API for rigid bodies, colliders, and joints to add realistic physics to your TresJS scenes.
 
+::prose-warning
+`@tresjs/rapier` is currently in **alpha**. The API is not stable yet and may introduce breaking changes between releases without a major version bump. Pin the exact version in your `package.json` and check the release notes before upgrading.
+::
+
 ## Next Steps
 
 Continue your journey:

--- a/apps/rapier-docs/content/1.getting-started/2.installation.md
+++ b/apps/rapier-docs/content/1.getting-started/2.installation.md
@@ -9,16 +9,20 @@ To install the package manually on an existing project:
 
  ::code-group
 ```bash [pnpm]
-pnpm add @tresjs/rapier
+pnpm add @tresjs/rapier@alpha
 ```
 
 ```bash [npm]
-npm install @tresjs/rapier
+npm install @tresjs/rapier@alpha
 ```
 
 ```bash [yarn]
-yarn add @tresjs/rapier
+yarn add @tresjs/rapier@alpha
 ```
+::
+
+::prose-warning
+The package is published under the `alpha` dist-tag while the API stabilizes — expect breaking changes between releases. Pin the exact version in your `package.json`.
 ::
 
 <!-- ## Via `create-tres` wizard

--- a/packages/rapier/package.json
+++ b/packages/rapier/package.json
@@ -2,7 +2,6 @@
   "name": "@tresjs/rapier",
   "type": "module",
   "version": "0.0.0",
-  "private": true,
   "description": "TresJs physics support, powered by rapier",
   "author": "Alvaro Saburido <hola@alvarosaburido.dev> (https://github.com/alvarosabu/)",
   "license": "MIT",
@@ -50,7 +49,7 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "@tresjs/core": "5.3.2",
+    "@tresjs/core": "^5.3.2",
     "three": ">=0.169",
     "vue": ">=3.4.0"
   },

--- a/packages/rapier/package.json
+++ b/packages/rapier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tresjs/rapier",
   "type": "module",
-  "version": "0.0.0",
+  "version": "1.0.0-alpha.0",
   "description": "TresJs physics support, powered by rapier",
   "author": "Alvaro Saburido <hola@alvarosaburido.dev> (https://github.com/alvarosabu/)",
   "license": "MIT",
@@ -26,14 +26,16 @@
     "Jaime Torrealba (https://github.com/JaimeTorrealba)"
   ],
   "exports": {
-    ".": "./dist/tresrapier.js",
+    ".": {
+      "types": "./dist/tresrapier.d.ts",
+      "default": "./dist/tresrapier.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/tresrapier.js",
   "module": "./dist/tresrapier.js",
   "types": "./dist/tresrapier.d.ts",
   "files": [
-    "*.d.ts",
     "dist"
   ],
   "publishConfig": {

--- a/packages/rapier/src/components/RigidBody.vue
+++ b/packages/rapier/src/components/RigidBody.vue
@@ -144,7 +144,6 @@ watch(() => props.sensor, value => setAutoColliderProp('sensor', value))
 watch(() => props.activeContactForce, value => setAutoColliderProp('activeContactForce', value))
 watch(() => props.contactForceEventThreshold, value => setAutoColliderProp('contactForceEventThreshold', value))
 
-
 watch([() => props.lockTranslations, instance], ([_lockTranslations, _]) => {
   if (!instance.value) { return }
   instance.value.lockTranslations(_lockTranslations, true)


### PR DESCRIPTION
## Summary

Prepares `@tresjs/rapier` for its first npm publish under the `alpha` dist-tag.

### Package (`packages/rapier`)
- Remove `"private": true` so the package joins the publishable set (`tag:npm:public`) and CI builds
- Bump version to `1.0.0-alpha.0`
- Loosen `@tresjs/core` peer dep from exact `5.3.2` to `^5.3.2`
- Add explicit `types` condition to `exports["."]` (was relying on sibling `.d.ts` fallback)
- Drop stale `"*.d.ts"` glob from `files` (no root-level `.d.ts` exists)

### Docs (`apps/rapier-docs`)
- Add alpha notice to Getting Started warning about breaking changes between releases
- Update install commands to `@tresjs/rapier@alpha` (plain install would fail while only the `alpha` dist-tag exists) with a dist-tag warning

## Publish plan (post-merge, manual first time)
1. `pnpm nx build @tresjs/rapier`
2. `cd packages/rapier && pnpm publish --tag alpha`
3. `git tag "@tresjs/rapier@1.0.0-alpha.0" && git push --tags`
4. Configure npm trusted publishing for the package so future releases go through the Publish workflow

## Test plan
- [x] `npm pack --dry-run` — tarball contains only `LICENSE`, `README.md`, `dist/tresrapier.{js,d.ts}`, `package.json`
- [x] Built bundle externalizes `vue`, `three`, `@tresjs/core`, `@vueuse/core`, `@dimforge/rapier3d-compat`
- [ ] CI green (rapier now included in `build:ci`)