### PR TITLE
fix(core): drop three-stdlib dependency to cut install size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,8 +59,7 @@
     "@pmndrs/pointer-events": "catalog:",
     "@vue/devtools-api": "catalog:",
     "@vueuse/core": "catalog:utils",
-    "radashi": "catalog:",
-    "three-stdlib": "catalog:three"
+    "radashi": "catalog:"
   },
   "devDependencies": {
     "@tresjs/eslint-config": "workspace:*",

--- a/packages/core/src/directives/vLightHelper.ts
+++ b/packages/core/src/directives/vLightHelper.ts
@@ -8,7 +8,7 @@ import {
   PointLightHelper,
   SpotLightHelper,
 } from 'three'
-import { RectAreaLightHelper } from 'three-stdlib'
+import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper.js'
 import { logWarning } from '../utils/logger'
 import { isLight } from '../utils/is'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,9 +963,6 @@ importers:
       radashi:
         specifier: 'catalog:'
         version: 12.9.1
-      three-stdlib:
-        specifier: catalog:three
-        version: 2.36.1(three@0.184.0)
     devDependencies:
       '@tresjs/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

`@tresjs/core@5.8.2` install size jumped ~1,007% (~28 MB) vs 5.8.1. Cause: `three-stdlib` became a hard dependency (via #1437's dep bump), but it's used in core for **exactly one import** — `RectAreaLightHelper` in `vLightHelper.ts`.

This drops the 28 MB dependency entirely by importing the helper from `three` directly, which is already a `peerDependency` (`three >=0.133`). `three-stdlib` is just a repackaging of `three`'s `examples/jsm`, so this is the same class at zero install cost.

## Changes

- `vLightHelper.ts`: import `RectAreaLightHelper` from `three/examples/jsm/helpers/RectAreaLightHelper.js` instead of `three-stdlib`
- `packages/core/package.json`: remove `three-stdlib` from `dependencies`
- `pnpm-lock.yaml`: updated (cientos still depends on `three-stdlib`, catalog entry untouched)

## Impact

- Install size: **−~28 MB** for `@tresjs/core` (reverts the full 5.8.2 regression)
- No behavior change — identical helper class
- bundlephobia was unaffected by the regression because it measures the tree-shaken JS bundle, not the on-disk dependency tree

## Test plan

- [x] `nr build` passes; dist externalizes to `three/...`, zero `three-stdlib` references in output
- [x] `nr test:ci` — 528 passed (3 skipped)
- [ ] CI note: `nr typecheck` reports 2 errors in `Context.vue` and `useLoader/component.vue` — both **pre-existing on `main`** and unrelated to this change