### PR TITLE
feat(core): expose isWebGPURenderer guard + reactive isWebGPU flag

### DIFF
--- a/packages/core/src/composables/useRenderer/useRendererManager.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.ts
@@ -19,7 +19,7 @@ import { logWarning } from '../../utils/logger'
 import type { SizesType } from '../useSizes'
 import type { UseCameraReturn } from '../useCamera'
 import type { TresScene } from '../../types'
-import { isFunction, isObject } from '../../utils/is'
+import { isFunction, isWebGPURenderer } from '../../utils/is'
 import { useCreateRafLoop } from '../useCreateRafLoop'
 import { TresRendererError } from '../../utils/error'
 
@@ -269,10 +269,6 @@ export function useRendererManager(
 
   const isModeAlways = computed(() => toValue(options.renderMode) === 'always')
 
-  // be aware that the WebGLRenderer does not extend from Renderer
-  const isRenderer = (value: unknown): value is Renderer =>
-    isObject(value) && 'isRenderer' in value && Boolean(value.isRenderer)
-
   const readyEventHook = createEventHook<TresRenderer>()
   const errorEventHook = createEventHook<TresRendererError>()
   let hasTriggeredReady = false
@@ -284,7 +280,7 @@ export function useRendererManager(
   // Initialize renderer asynchronously (required for WebGPU in Three.js r181+)
   const initializeRenderer = async () => {
     try {
-      if (isRenderer(renderer)) {
+      if (isWebGPURenderer(renderer)) {
         // WebGPU renderer requires awaiting init() before any operations
         await renderer.init()
       }

--- a/packages/core/src/composables/useTres/index.ts
+++ b/packages/core/src/composables/useTres/index.ts
@@ -38,7 +38,7 @@ export interface TresPartialContext extends Omit<TresContext, 'renderer' | 'came
 }
 
 export function useTres(): TresPartialContext {
-  const { scene, renderer, camera, sizes, controls, extend, events } = useTresContext()
+  const { scene, renderer, camera, sizes, controls, extend, events, isWebGPU } = useTresContext()
 
   return {
     scene,
@@ -48,6 +48,7 @@ export function useTres(): TresPartialContext {
     controls,
     extend,
     events,
+    isWebGPU,
     invalidate: renderer.invalidate,
     advance: renderer.advance,
   }

--- a/packages/core/src/composables/useTresContextProvider/index.ts
+++ b/packages/core/src/composables/useTresContextProvider/index.ts
@@ -1,9 +1,10 @@
-import type { MaybeRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
+import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 
 import type { TresControl, TresScene } from '../../types'
 import type { RendererOptions, UseRendererManagerReturn } from '../useRenderer/useRendererManager'
-import { ref, shallowRef } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { extend } from '../../core/catalogue'
+import { isWebGPURenderer } from '../../utils/is'
 
 import type { UseCameraReturn } from '../useCamera'
 
@@ -21,6 +22,15 @@ export interface TresContext {
   camera: UseCameraReturn
   controls: Ref<TresControl | null>
   renderer: UseRendererManagerReturn
+  /**
+   * Whether the active renderer is a Three.js WebGPU `Renderer` (as opposed to a
+   * `WebGLRenderer`). Reactive so downstream components can branch on it without
+   * re-deriving it from `renderer.instance`.
+   *
+   * Note: this reflects the renderer instance, not the active backend — a
+   * `WebGPURenderer` running on its WebGL2 fallback still reports `true`.
+   */
+  isWebGPU: ComputedRef<boolean>
   events: ReturnType<typeof useEventManager>
 }
 
@@ -64,6 +74,7 @@ const [useTresContextProvider, _useTresContext] = createInjectionState(({
     scene: localScene,
     camera,
     renderer,
+    isWebGPU: computed(() => isWebGPURenderer(renderer.instance)),
     controls: ref(null),
     extend,
     events,

--- a/packages/core/src/utils/is/is.test.ts
+++ b/packages/core/src/utils/is/is.test.ts
@@ -1,6 +1,6 @@
 import type { Camera, Light, Material, Object3D } from 'three'
 import { AmbientLight, BufferGeometry, DirectionalLight, Fog, Group, Mesh, MeshBasicMaterial, MeshNormalMaterial, OrthographicCamera, PerspectiveCamera, PointLight, Scene } from 'three'
-import { isBufferGeometry, isCamera, isFog, isLight, isMaterial, isObject3D, isScene, isTresObject } from '../is/index'
+import { isBufferGeometry, isCamera, isFog, isLight, isMaterial, isObject3D, isScene, isTresObject, isWebGLRenderer, isWebGPURenderer } from '../is/index'
 
 // TODO move file
 const NUMBERS: Record<string, number> = {
@@ -88,7 +88,18 @@ const BUFFER_GEOMETRIES: Record<string, BufferGeometry> = {
   bufferGeometry: new BufferGeometry(),
 }
 
-const OBJECTS = Object.assign({}, { '{}': {}, '{ a: "a" }': { a: 'a' } }, FOGS, MATERIALS, OBJECT3DS, BUFFER_GEOMETRIES)
+// WebGPU `Renderer` sets `isRenderer = true`; `WebGLRenderer` sets `isWebGLRenderer = true`.
+// jsdom has no GPU/GL context to instantiate real renderers, so we stand in with the
+// marker flags the guards actually check (mirrors how the suite mocks WebGLRenderer).
+const WEBGPU_RENDERERS: Record<string, any> = {
+  webGPURenderer: { isRenderer: true },
+}
+
+const WEBGL_RENDERERS: Record<string, any> = {
+  webGLRenderer: { isWebGLRenderer: true },
+}
+
+const OBJECTS = Object.assign({}, { '{}': {}, '{ a: "a" }': { a: 'a' } }, FOGS, MATERIALS, OBJECT3DS, BUFFER_GEOMETRIES, WEBGPU_RENDERERS, WEBGL_RENDERERS)
 
 const TRES_OBJECTS = Object.assign({}, MATERIALS, OBJECT3DS, BUFFER_GEOMETRIES, FOGS)
 
@@ -103,6 +114,8 @@ describe('is', () => {
   describe('isFog(a: any)', () => { test(isFog, FOGS) })
   describe('isScene(a: any)', () => { test(isScene, SCENES) })
   describe('isTresObject(a: any)', () => { test(isTresObject, TRES_OBJECTS) })
+  describe('isWebGPURenderer(a: any)', () => { test(isWebGPURenderer, WEBGPU_RENDERERS) })
+  describe('isWebGLRenderer(a: any)', () => { test(isWebGLRenderer, WEBGL_RENDERERS) })
 })
 
 /**

--- a/packages/core/src/utils/is/tres.ts
+++ b/packages/core/src/utils/is/tres.ts
@@ -1,3 +1,5 @@
+import type { WebGLRenderer } from 'three'
+import type { Renderer } from 'three/webgpu'
 import type { TresCamera, TresInstance, TresObject, TresPrimitive } from '../../types'
 import { isBufferGeometry, isCamera, isFog, isMaterial, isObject3D, isOrthographicCamera, isPerspectiveCamera } from './three'
 import { createTypeGuard } from './util'
@@ -75,3 +77,33 @@ export const isTresPrimitive = createTypeGuard<TresPrimitive>('isPrimitive')
  */
 export const isTresInstance = (value: unknown): value is TresInstance =>
   isTresObject(value) && '__tres' in value
+
+/**
+ * Type guard to check if a value is a Three.js WebGPU `Renderer`.
+ *
+ * Identifies the renderer *instance*, not the active backend: a `WebGPURenderer`
+ * can run on a WebGPU **or** a WebGL2 fallback backend, and this returns `true`
+ * for both. That is the right granularity for branching on capabilities —
+ * `NodeMaterial` works on either backend, while a GLSL `ShaderMaterial` works on
+ * neither under the WebGPU renderer.
+ * @param value - The value to check
+ * @returns True if the value is a WebGPU `Renderer` instance, false otherwise
+ * @example
+ * ```ts
+ * const { renderer } = useTresContext()
+ * if (isWebGPURenderer(renderer.instance)) {
+ *   // TypeScript knows renderer.instance is a WebGPU Renderer here
+ * }
+ * ```
+ */
+export const isWebGPURenderer = createTypeGuard<Renderer>('isRenderer')
+
+/**
+ * Type guard to check if a value is a Three.js `WebGLRenderer`.
+ * @param value - The value to check
+ * @returns True if the value is a `WebGLRenderer` instance, false otherwise
+ * @see {@link isWebGPURenderer}
+ */
+// `WebGLRenderer` sets `isWebGLRenderer = true` at runtime, but three's types omit
+// the flag — intersect it in so `createTypeGuard` accepts the key.
+export const isWebGLRenderer = createTypeGuard<WebGLRenderer & { isWebGLRenderer: true }>('isWebGLRenderer')


### PR DESCRIPTION
## Summary

Surfaces the renderer type to the ecosystem so components can branch internally. Core already supports WebGPU and had the detection logic internally — this promotes it to public API.

- Add public guards `isWebGPURenderer(value): value is Renderer` and `isWebGLRenderer(value): value is WebGLRenderer` in `utils/is/tres.ts`, following the existing `createTypeGuard` pattern. The `isRenderer` / `isWebGLRenderer` marker flags are mutually exclusive (verified against three 0.184), so the guards never both match.
- Expose a reactive `isWebGPU: ComputedRef<boolean>` on `TresContext`, computed from `renderer.instance`. Also surfaced through `useTres()`.
- Reuse the new `isWebGPURenderer` guard inside `useRendererManager` (drops the duplicated inline `isRenderer`).
- Unit tests for both guards, mirroring the existing guard suite.

### Notes

`WebGPURenderer` can run on a WebGPU **or** a WebGL2 fallback backend. The guard identifies the renderer *instance*, not the active backend — the right granularity here (`NodeMaterial` works on both backends; GLSL `ShaderMaterial` works on neither under the WebGPU renderer).

`three`'s `WebGLRenderer` type omits the runtime `isWebGLRenderer` flag, so `isWebGLRenderer` intersects `{ isWebGLRenderer: true }` to satisfy `createTypeGuard`'s `keyof`.

## Test plan

- [x] `import { isWebGPURenderer } from '@tresjs/core'` works (exported via main index, confirmed in `dist/tres.d.ts`)
- [x] `const { isWebGPU } = useTresContext()` is reactive and correct for both renderers
- [x] Unit tests pass (`632 passed | 3 skipped`)
- [x] Typecheck clean (no new errors)
- [x] Lint + build pass

Closes TRES-329