### PR TITLE
fix(docs): restore MDC page slots mangled into headings

### DIFF
--- a/apps/cientos-docs/CLAUDE.md
+++ b/apps/cientos-docs/CLAUDE.md
@@ -202,10 +202,10 @@ cta:
   - /getting-started
 ---
 
-# title
+#title
 Hero Title
 
-# description
+#description
 Hero description
 ::
 ```

--- a/apps/cientos-docs/content/index.md
+++ b/apps/cientos-docs/content/index.md
@@ -23,12 +23,12 @@ Tres v5 announcement
 :::
  -->
 
-# title
+#title
 
 <span class="text-primary-300">Cientos</span> \
 Ready-made abstractions for TresJS
 
-# description
+#description
 Extending helpers and composables using Three.js addons.
 
 #links
@@ -56,7 +56,7 @@ Extending helpers and composables using Three.js addons.
 ::
 
 ::u-page-section
-# title
+#title
 Features you will love
 
 #links
@@ -72,7 +72,7 @@ Features you will love
   Explore the lab
   :::
 
-# features
+#features
 
   :::u-page-feature
   ---
@@ -80,7 +80,7 @@ Features you will love
   target: _blank
   to: https://github.com/pmndrs/three-stdlib
   ---
-  # title
+  #title
   three-stdlib
 
   #description
@@ -92,10 +92,10 @@ Features you will love
   target: _blank
   to: https://threejs.org
   ---
-  # title
+  #title
   Extendable
 
-  # description
+  #description
   You want to create a fancy shader material component? Submit a PR 🤗.
   :::
 
@@ -105,7 +105,7 @@ Features you will love
   target: _blank
   to: https://ui.nuxt.com
   ---
-  # title
+  #title
   Community-Driven
   #description
   Benefits from the active and growing Vue TresJS community.
@@ -117,10 +117,10 @@ Features you will love
   target: _blank
   to: https://www.typescriptlang.org
   ---
-  # title
+  #title
   TypeScript
 
-  # description
+  #description
   A fully typed development experience.
   :::
 ::

--- a/apps/cientos-docs/eslint.config.mjs
+++ b/apps/cientos-docs/eslint.config.mjs
@@ -5,10 +5,11 @@ export default tresLintConfig(
     ignores: ['.data/**', 'CLAUDE.md'],
   },
   {
-    // Nuxt UI landing pages use MDC slots (`# title`, `# description`) inside
-    // page components, which legitimately produce multiple H1s.
+    // MDC slot directives (`#title`) have no space after `#`; these rules would
+    // "fix" them into `# title` headings and break the slots. See #1437.
     files: ['content/**/*.md'],
     rules: {
+      'markdown/no-missing-atx-heading-space': 'off',
       'markdown/no-multiple-h1': 'off',
     },
   },

--- a/apps/docs-boilerplate/content/index.md
+++ b/apps/docs-boilerplate/content/index.md
@@ -23,12 +23,12 @@ Tres v5 announcement
 :::
  -->
 
-# title
+#title
 
 <span class="text-primary-300">TresJS</span> \
 Bring Three to the Vue ecosystem
 
-# description
+#description
 Create awesome Three-based experiences with the framework you love.
 
 #links
@@ -56,7 +56,7 @@ Create awesome Three-based experiences with the framework you love.
 ::
 
 ::u-page-section
-# title
+#title
 Features you will love
 
 #links
@@ -78,10 +78,10 @@ Features you will love
   icon: i-lucide-lightbulb
   target: _blank
   ---
-  # title
+  #title
   Declarative
 
-  # description
+  #description
   Build 3D scenes with familiar Vue components and composables.
   :::
 
@@ -91,10 +91,10 @@ Features you will love
   target: _blank
   to: https://threejs.org
   ---
-  # title
+  #title
   Up to date with Three.js
 
-  # description
+  #description
   Enjoy the latest features right away.
   :::
 
@@ -104,7 +104,7 @@ Features you will love
   target: _blank
   to: https://ui.nuxt.com
   ---
-  # title
+  #title
   DX focused
   #description
   Inspect your 3D scenes like never before with official devtools.
@@ -116,10 +116,10 @@ Features you will love
   target: _blank
   to: https://www.typescriptlang.org
   ---
-  # title
+  #title
   TypeScript
 
-  # description
+  #description
   A fully typed development experience.
   :::
 
@@ -129,10 +129,10 @@ Features you will love
   target: _blank
   to: https://nuxt.com/modules/tresjs
   ---
-  # title
+  #title
   Nuxt module
 
-  # description
+  #description
   Enjoy the best of both worlds with a fully integrated experience.
   :::
 
@@ -142,10 +142,10 @@ Features you will love
   target: _blank
 
   ---
-  # title
+  #title
   Ecosystem
 
-  # description
+  #description
   Extend the core functionality with packages such as cientos and postprocessing or add your own custom packages.
   :::
 ::

--- a/apps/docs-boilerplate/eslint.config.mjs
+++ b/apps/docs-boilerplate/eslint.config.mjs
@@ -5,10 +5,11 @@ export default tresLintConfig(
     ignores: ['.data/**', 'CLAUDE.md'],
   },
   {
-    // Nuxt UI landing pages use MDC slots (`# title`, `# description`) inside
-    // page components, which legitimately produce multiple H1s.
+    // MDC slot directives (`#title`) have no space after `#`; these rules would
+    // "fix" them into `# title` headings and break the slots. See #1437.
     files: ['content/**/*.md'],
     rules: {
+      'markdown/no-missing-atx-heading-space': 'off',
       'markdown/no-multiple-h1': 'off',
     },
   },

--- a/apps/postprocessing-docs/content/index.md
+++ b/apps/postprocessing-docs/content/index.md
@@ -6,12 +6,12 @@ seo:
 
 ::u-page-hero
 
-# title
+#title
 
 <span class="text-primary-300">Post-processing</span> \
 Effect composer library for TresJS
 
-# description
+#description
 Enhance the rendering flow with passes and effects — bloom, depth of field, glitch, god rays and more.
 
 #links
@@ -39,19 +39,19 @@ Enhance the rendering flow with passes and effects — bloom, depth of field, gl
 ::
 
 ::u-page-section
-# title
+#title
 Why Post-processing?
 
-# features
+#features
 
   :::u-page-feature
   ---
   icon: i-lucide-wand-sparkles
   ---
-  # title
+  #title
   Declarative & Simple
 
-  # description
+  #description
   Add post-processing passes and effects with Vue components.
   :::
 
@@ -61,10 +61,10 @@ Why Post-processing?
   target: _blank
   to: https://github.com/pmndrs/postprocessing
   ---
-  # title
+  #title
   Performant
 
-  # description
+  #description
   Powered by `pmndrs/postprocessing` under the hood for maximum performance.
   :::
 
@@ -72,10 +72,10 @@ Why Post-processing?
   ---
   icon: i-lucide-sparkles
   ---
-  # title
+  #title
   Visually Awesome
 
-  # description
+  #description
   Bloom, chromatic aberration, glitch, depth of field — it just looks super cool.
   :::
 
@@ -85,10 +85,10 @@ Why Post-processing?
   target: _blank
   to: https://www.typescriptlang.org
   ---
-  # title
+  #title
   TypeScript
 
-  # description
+  #description
   A fully typed development experience.
   :::
 ::

--- a/apps/postprocessing-docs/eslint.config.mjs
+++ b/apps/postprocessing-docs/eslint.config.mjs
@@ -5,10 +5,11 @@ export default tresLintConfig(
     ignores: ['.data/**', 'CLAUDE.md'],
   },
   {
-    // Nuxt UI landing pages use MDC slots (`# title`, `# description`) inside
-    // page components, which legitimately produce multiple H1s.
+    // MDC slot directives (`#title`) have no space after `#`; these rules would
+    // "fix" them into `# title` headings and break the slots. See #1437.
     files: ['content/**/*.md'],
     rules: {
+      'markdown/no-missing-atx-heading-space': 'off',
       'markdown/no-multiple-h1': 'off',
     },
   },


### PR DESCRIPTION
  ## Problem

  The three docs landing pages render broken and throw a Vue hydration mismatch on the homepage. #1437 bumped `@eslint/markdown` to v8, where `markdown/no-missing-atx-heading-space` is on by default. A `lint --fix` run then rewrote the MDC slot directives (`#title`, `#description`, `#features`) into ATX headings (`# title`, ...) in `content/index.md` across cientos-docs, docs-boilerplate and postprocessing-docs, plus the cientos-docs `CLAUDE.md` example.

  `remark-mdc` only treats `#name` as a slot when a letter follows the `#` immediately. With a space, it falls back to CommonMark and becomes an `<h1>`, so the hero/section/feature text stopped filling the Nuxt UI components' named slots and fell into their default slots. That is what broke the pages and triggered the hydration mismatch.

  ## Fix

  - Revert the slot syntax in the three `index.md` landing pages and the cientos-docs `CLAUDE.md` example (now byte-identical to the pre-#1437 state).
  - Turn off `markdown/no-missing-atx-heading-space` (and keep `no-multiple-h1` off) for `content/**/*.md`, so the linter stops rewriting MDC slot directives back into headings. Also corrected the misleading comment that called `# title` the MDC syntax.

  ## Verification
  
  `pnpm --filter cientos-docs lint && pnpm --filter docs-boilerplate lint && pnpm --filter postprocessing-docs lint` passes clean.