### PR TITLE
feat(cientos): add Text component (SDF text via troika-three-text)

### DIFF
--- a/apps/cientos-docs/app/components/objects/SdfText.vue
+++ b/apps/cientos-docs/app/components/objects/SdfText.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { OrbitControls, Text } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { NoToneMapping, SRGBColorSpace } from 'three'
+import { ref } from 'vue'
+import { useControls } from '@tresjs/leches'
+
+const uuid = inject(`uuid`)
+
+const gl = {
+  clearColor: '#1a1a1a',
+  alpha: false,
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+}
+
+const reactiveText = ref('Hello TresJS — render crisp, scalable SDF text from real font files.')
+
+const {
+  fontSize,
+  color,
+  maxWidth,
+  textAlign,
+  anchorX,
+  outlineWidth,
+  outlineColor,
+  strokeWidth,
+} = useControls({
+  fontSize: { value: 0.6, min: 0.1, max: 2, step: 0.05 },
+  color: '#ffffff',
+  maxWidth: { value: 6, min: 1, max: 12, step: 0.5 },
+  textAlign: { value: 'center', options: ['left', 'center', 'right', 'justify'] },
+  anchorX: { value: 'center', options: ['left', 'center', 'right'] },
+  outlineWidth: { value: 0, min: 0, max: 0.1, step: 0.005 },
+  outlineColor: '#000000',
+  strokeWidth: { value: 0, min: 0, max: 0.05, step: 0.002 },
+}, { uuid })
+</script>
+
+<template>
+  <div class="bg-gray-100 flex justify-center absolute top-0 left-0 w-full h-full">
+    <input
+      v-model="reactiveText"
+      class="p-2 m-2 rounded-md bg-white border text-red-500 border-gray-400"
+    />
+  </div>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[0, 0, 6]" />
+    <OrbitControls />
+    <Text
+      :text="reactiveText"
+      :font-size="fontSize"
+      :color="color"
+      :max-width="maxWidth"
+      :text-align="textAlign"
+      :anchor-x="anchorX"
+      anchor-y="middle"
+      :outline-width="outlineWidth"
+      :outline-color="outlineColor"
+      :stroke-width="strokeWidth"
+      stroke-color="#ff0000"
+    />
+    <TresAmbientLight :intensity="1" />
+  </TresCanvas>
+</template>

--- a/apps/cientos-docs/content/2.api/9.objects/text.md
+++ b/apps/cientos-docs/content/2.api/9.objects/text.md
@@ -1,0 +1,104 @@
+---
+title: Text
+description: Render high-quality SDF text from real font files using troika-three-text.
+---
+
+::SceneControlsWrapper
+  ::ObjectsSdfText
+  ::
+::
+
+`<Text />` renders crisp, scalable text using [SDF (signed distance field)](https://en.wikipedia.org/wiki/Signed_distance_function) glyphs, wrapping [`troika-three-text`](https://github.com/protectwise/troika/tree/main/packages/troika-three-text). It consumes real `.ttf`, `.otf` and `.woff` font files at runtime and supports kerning, ligatures, RTL/bidi and unicode fallback.
+
+The component owns the underlying troika `Text` instance: it calls `.sync()` whenever props change and disposes of the instance automatically when unmounted, so you never need the manual `<primitive>` wiring.
+
+## Text3D vs Text — which do I use?
+
+::prose-note
+Use **`<Text3D>`** for chunky, extruded 3D titles from a pre-baked `typeface.json` font. Use **`<Text>`** for labels, UI, body copy and multilingual content where kerning, wrapping and unicode fallback matter.
+::
+
+| | `<Text3D>` | `<Text>` |
+| :--- | :--- | :--- |
+| **Technique** | Extruded `TextGeometry` | SDF, runtime-generated |
+| **Font input** | pre-baked `typeface.json` | real `.ttf` / `.otf` / `.woff` |
+| **Kerning / ligatures / RTL** | ✗ | ✓ |
+| **Unicode fallback** | ✗ | ✓ |
+| **Best for** | 3D titles | labels, UI, multilingual |
+
+## Usage
+
+The text can be provided through the `text` prop or the default slot. By default the [Roboto](https://fonts.google.com/specimen/Roboto) font is loaded from Google Fonts; pass the `font` prop to use your own font file.
+
+::prose-note
+For dynamic or reactive content, prefer the `text` prop. The default slot is best for static strings, since reactive values interpolated into the slot may not always re-trigger an update.
+::
+
+```vue
+<script setup lang="ts">
+import { Text } from '@tresjs/cientos'
+</script>
+
+<template>
+  <TresCanvas>
+    <TresPerspectiveCamera :position="[0, 0, 6]" />
+    <Text
+      text="Hello TresJS"
+      font="/fonts/Inter.woff"
+      :font-size="0.5"
+      color="#ffffff"
+      anchor-x="center"
+      anchor-y="middle"
+      :max-width="4"
+      @sync="onSync"
+    />
+  </TresCanvas>
+</template>
+```
+
+Any extra props (such as `position`, `rotation` or `scale`) are forwarded to the underlying object.
+
+## Events
+
+| Event    | Description                                                                                   |
+| :------- | :-------------------------------------------------------------------------------------------- |
+| **sync** | Fires after the text layout has completed (`.sync()`). The troika `Text` instance is emitted. |
+
+## Props
+
+| Prop                    | Description                                                                                     | Default    |
+| :---------------------- | :---------------------------------------------------------------------------------------------- | ---------- |
+| **text**                | The string of text to render. Can also be provided via the default slot.                        |            |
+| **characters**          | The set of characters to pre-generate SDF glyphs for.                                           | `null`        |
+| **color**               | The color of the text.                                                                          | white         |
+| **fontSize**            | The em-height at which to render the font, in local world units.                                | `1`           |
+| **fontWeight**          | The weight of the font (variable fonts only).                                                   | `normal`      |
+| **fontStyle**           | The style of the font, `normal` or `italic`.                                                    | `normal`      |
+| **maxWidth**            | The maximum width of the text block, above which lines wrap.                                    | `Infinity`    |
+| **lineHeight**          | The height of each line of text, as a multiple of `fontSize`.                                   | `normal`      |
+| **letterSpacing**       | Spacing between letters after layout, in local world units.                                     | `0`           |
+| **textAlign**           | Horizontal alignment: `left`, `right`, `center` or `justify`.                                   | `left`        |
+| **font**                | URL of a custom font file (`.ttf`, `.otf`, `.woff`).                                            | Roboto        |
+| **anchorX**             | Horizontal position in the text block that lines up with the local origin.                      | `'center'`    |
+| **anchorY**             | Vertical position in the text block that lines up with the local origin.                        | `'middle'`    |
+| **clipRect**            | Clipping region `[minX, minY, maxX, maxY]` in local units.                                      | `null`        |
+| **depthOffset**         | Fixed offset added to the text's rendered z-depth (helps prevent z-fighting).                   | `0`           |
+| **direction**           | Base text direction: `auto`, `ltr` or `rtl`.                                                    | `auto`        |
+| **overflowWrap**        | How text wraps when a word is too long: `normal` or `break-word`.                               | `normal`      |
+| **whiteSpace**          | Whitespace handling: `normal` or `nowrap`.                                                       | `normal`      |
+| **outlineWidth**        | Width of an outline/halo drawn around each glyph.                                               | `0`           |
+| **outlineOffsetX**      | Horizontal offset of the text outline.                                                          | `0`           |
+| **outlineOffsetY**      | Vertical offset of the text outline.                                                            | `0`           |
+| **outlineBlur**         | Blur radius applied to the text outline.                                                        | `0`           |
+| **outlineColor**        | Color of the text outline.                                                                      | black         |
+| **outlineOpacity**      | Opacity of the text outline.                                                                    | `1`           |
+| **strokeWidth**         | Width of an inner stroke drawn on each glyph.                                                   | `0`           |
+| **strokeColor**         | Color of the glyph stroke.                                                                      | grey          |
+| **strokeOpacity**       | Opacity of the glyph stroke.                                                                    | `1`           |
+| **fillOpacity**         | Opacity of the glyph fill.                                                                      | `1`           |
+| **sdfGlyphSize**        | The size of each glyph's SDF texture, in pixels.                                                | `64`          |
+| **glyphGeometryDetail** | The level of detail of each glyph's geometry tessellation.                                      | `1`           |
+
+::prose-note
+Only `fontSize`, `anchorX`, `anchorY` and `sdfGlyphSize` are defaulted by the component. All other defaults are applied by `troika-three-text` itself, so the values above reflect troika's behaviour when the prop is left unset.
+::

--- a/apps/docs/content/3.api/5.advanced/primitives.md
+++ b/apps/docs/content/3.api/5.advanced/primitives.md
@@ -466,6 +466,20 @@ textMesh.color = 0xFF6600
 </template>
 ```
 
+::note
+For SDF text you usually don't need the manual `<primitive>` wiring above. The [`<Text>`](https://cientos.tresjs.org/api/objects/text) component from `@tresjs/cientos` wraps `troika-three-text` for you — it calls `.sync()` on prop changes and disposes of the instance automatically:
+
+```vue
+<script setup lang="ts">
+import { Text } from '@tresjs/cientos'
+</script>
+
+<template>
+  <Text text="Hello TresJS!" :font-size="0.5" color="#FF6600" />
+</template>
+```
+::
+
 ### 2. Custom Geometries
 ```vue
 <script setup lang="ts">

--- a/apps/playground/src/pages/cientos/objects/TextDemo.vue
+++ b/apps/playground/src/pages/cientos/objects/TextDemo.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { OrbitControls, Text } from '@tresjs/cientos'
+import { TresCanvas } from '@tresjs/core'
+import { NoToneMapping, SRGBColorSpace } from 'three'
+
+const gl = {
+  clearColor: '#1a1a1a',
+  alpha: false,
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+}
+</script>
+
+<template>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[0, 0, 8]" />
+    <OrbitControls />
+
+    <!-- Basic label -->
+    <Text
+      text="Hello TresJS"
+      :font-size="0.6"
+      color="#ffffff"
+      :position="[0, 2.5, 0]"
+    />
+
+    <!-- maxWidth wrapping -->
+    <Text
+      text="This is a longer paragraph of SDF text that wraps onto multiple lines thanks to maxWidth."
+      :font-size="0.3"
+      color="#82dbc5"
+      :max-width="5"
+      text-align="center"
+      :position="[0, 1, 0]"
+    />
+
+    <!-- Anchoring (left-anchored) -->
+    <Text
+      text="Left anchored"
+      :font-size="0.4"
+      color="#ffcc00"
+      anchor-x="left"
+      :position="[-3, -0.5, 0]"
+    />
+
+    <!-- Outline -->
+    <Text
+      text="Outlined"
+      :font-size="0.7"
+      color="#ff6600"
+      outline-width="8%"
+      outline-color="#000000"
+      :position="[0, -1.8, 0]"
+    />
+
+    <!-- Non-Latin string (unicode fallback) -->
+    <Text
+      text="こんにちは 你好 مرحبا"
+      :font-size="0.45"
+      color="#ffffff"
+      :position="[0, -3, 0]"
+    />
+
+    <TresGridHelper :args="[20, 20]" :position="[0, -4, 0]" />
+    <TresAmbientLight :intensity="1" />
+  </TresCanvas>
+</template>

--- a/apps/playground/src/router/routes/cientos/objects.ts
+++ b/apps/playground/src/router/routes/cientos/objects.ts
@@ -45,6 +45,11 @@ export const objectsRoutes = [
     component: () => import('@/pages/cientos/objects/ReflectorMeshDemo.vue'),
   },
   {
+    path: '/cientos/objects/text',
+    name: 'Text',
+    component: () => import('@/pages/cientos/objects/TextDemo.vue'),
+  },
+  {
     path: '/cientos/objects/text-3d',
     name: 'Text3D',
     component: () => import('@/pages/cientos/objects/Text3DDemo.vue'),

--- a/packages/cientos/package.json
+++ b/packages/cientos/package.json
@@ -60,7 +60,8 @@
     "stats.js": "catalog:",
     "three-custom-shader-material": "catalog:three",
     "three-mesh-bvh": "catalog:",
-    "three-stdlib": "catalog:three"
+    "three-stdlib": "catalog:three",
+    "troika-three-text": "catalog:three"
   },
   "devDependencies": {
     "@tresjs/core": "workspace:*",

--- a/packages/cientos/src/core/objects/Text.vue
+++ b/packages/cientos/src/core/objects/Text.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { useTres } from '@tresjs/core'
+import { Text as TroikaText } from 'troika-three-text'
+import { computed, onUnmounted, shallowRef, useSlots, watch } from 'vue'
+import type { Slots } from 'vue'
+import type { ColorRepresentation } from 'three'
+
+export interface TextProps {
+  /**
+   * The string of text to render. Can also be provided via the default slot.
+   *
+   * @type {string}
+   * @memberof TextProps
+   */
+  text?: string
+  /**
+   * The set of characters to include when generating the SDF glyphs.
+   * Useful for ensuring particular glyphs are pre-generated.
+   *
+   * @type {string}
+   * @memberof TextProps
+   */
+  characters?: string
+  /**
+   * The color of the text.
+   *
+   * @type {ColorRepresentation}
+   * @memberof TextProps
+   */
+  color?: ColorRepresentation
+  /**
+   * The em-height at which to render the font, in local world units.
+   *
+   * @type {number}
+   * @memberof TextProps
+   * @default 1
+   */
+  fontSize?: number
+  /**
+   * The weight of the font. Only used when `font` resolves to a variable font.
+   *
+   * @type {(number | 'normal' | 'bold')}
+   * @memberof TextProps
+   */
+  fontWeight?: number | 'normal' | 'bold'
+  /**
+   * The style of the font, either `normal` or `italic`.
+   *
+   * @type {('normal' | 'italic')}
+   * @memberof TextProps
+   */
+  fontStyle?: 'normal' | 'italic'
+  /**
+   * The maximum width of the text block, above which text may wrap lines.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  maxWidth?: number
+  /**
+   * The height of each line of text, as a multiple of the `fontSize`.
+   *
+   * @type {(number | 'normal')}
+   * @memberof TextProps
+   */
+  lineHeight?: number | 'normal'
+  /**
+   * Spacing between letters after layout, in local world units.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  letterSpacing?: number
+  /**
+   * The horizontal alignment of each line of text within the overall bounding box.
+   *
+   * @type {('left' | 'right' | 'center' | 'justify')}
+   * @memberof TextProps
+   */
+  textAlign?: 'left' | 'right' | 'center' | 'justify'
+  /**
+   * The URL of a custom font file to be used. Supports `.ttf`, `.otf` and `.woff`
+   * (not `.woff2`). Defaults to the Roboto font loaded from Google Fonts.
+   *
+   * @type {string}
+   * @memberof TextProps
+   */
+  font?: string
+  /**
+   * The horizontal position in the text block that should line up with the local origin.
+   *
+   * @type {(number | 'left' | 'center' | 'right' | string)}
+   * @memberof TextProps
+   * @default 'center'
+   */
+  anchorX?: number | 'left' | 'center' | 'right' | string
+  /**
+   * The vertical position in the text block that should line up with the local origin.
+   *
+   * @type {(number | 'top' | 'top-baseline' | 'middle' | 'bottom-baseline' | 'bottom' | string)}
+   * @memberof TextProps
+   * @default 'middle'
+   */
+  anchorY?: number | 'top' | 'top-baseline' | 'middle' | 'bottom-baseline' | 'bottom' | string
+  /**
+   * A rectangle defining a clipping region, as `[minX, minY, maxX, maxY]` in local units.
+   *
+   * @type {[number, number, number, number]}
+   * @memberof TextProps
+   */
+  clipRect?: [number, number, number, number]
+  /**
+   * Adds a fixed offset to the text's rendered z-depth, helping prevent z-fighting.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  depthOffset?: number
+  /**
+   * The base direction for the text, `ltr`, `rtl`, or `auto`.
+   *
+   * @type {('auto' | 'ltr' | 'rtl')}
+   * @memberof TextProps
+   */
+  direction?: 'auto' | 'ltr' | 'rtl'
+  /**
+   * Defines how text wraps if a single word is too long to fit within `maxWidth`.
+   *
+   * @type {('normal' | 'break-word')}
+   * @memberof TextProps
+   */
+  overflowWrap?: 'normal' | 'break-word'
+  /**
+   * Defines whitespace handling, following the CSS `white-space` property.
+   *
+   * @type {('normal' | 'nowrap')}
+   * @memberof TextProps
+   */
+  whiteSpace?: 'normal' | 'nowrap'
+  /**
+   * The width of an outline/halo drawn around each glyph.
+   *
+   * @type {(number | string)}
+   * @memberof TextProps
+   */
+  outlineWidth?: number | string
+  /**
+   * Horizontal offset of the text outline.
+   *
+   * @type {(number | string)}
+   * @memberof TextProps
+   */
+  outlineOffsetX?: number | string
+  /**
+   * Vertical offset of the text outline.
+   *
+   * @type {(number | string)}
+   * @memberof TextProps
+   */
+  outlineOffsetY?: number | string
+  /**
+   * The blur radius applied to the text outline.
+   *
+   * @type {(number | string)}
+   * @memberof TextProps
+   */
+  outlineBlur?: number | string
+  /**
+   * The color of the text outline.
+   *
+   * @type {ColorRepresentation}
+   * @memberof TextProps
+   */
+  outlineColor?: ColorRepresentation
+  /**
+   * The opacity of the text outline.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  outlineOpacity?: number
+  /**
+   * The width of an inner stroke drawn on each glyph.
+   *
+   * @type {(number | string)}
+   * @memberof TextProps
+   */
+  strokeWidth?: number | string
+  /**
+   * The color of the glyph stroke.
+   *
+   * @type {ColorRepresentation}
+   * @memberof TextProps
+   */
+  strokeColor?: ColorRepresentation
+  /**
+   * The opacity of the glyph stroke.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  strokeOpacity?: number
+  /**
+   * The opacity of the glyph fill.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  fillOpacity?: number
+  /**
+   * The size of each glyph's SDF (signed distance field) texture, in pixels.
+   *
+   * @type {number}
+   * @memberof TextProps
+   * @default 64
+   */
+  sdfGlyphSize?: number
+  /**
+   * The level of detail of each glyph's geometry tessellation.
+   *
+   * @type {number}
+   * @memberof TextProps
+   */
+  glyphGeometryDetail?: number
+}
+
+const props = withDefaults(defineProps<TextProps>(), {
+  anchorX: 'center',
+  anchorY: 'middle',
+  fontSize: 1,
+  sdfGlyphSize: 64,
+})
+
+const emit = defineEmits<{
+  sync: [instance: TroikaText]
+}>()
+
+const { invalidate } = useTres()
+
+const slots: Slots = useSlots()
+
+const localText = computed((): string => {
+  if (props.text !== undefined) { return props.text }
+  if (slots.default) { return (slots.default()[0]?.children as string)?.trim() ?? '' }
+  return ''
+})
+
+const instance = shallowRef(new TroikaText())
+
+defineExpose({
+  instance,
+})
+
+function syncText() {
+  const troika = instance.value
+  if (!troika) { return }
+
+  troika.text = localText.value
+  troika.characters = props.characters
+  troika.color = props.color
+  troika.fontSize = props.fontSize
+  troika.fontWeight = props.fontWeight
+  troika.fontStyle = props.fontStyle
+  troika.maxWidth = props.maxWidth
+  troika.lineHeight = props.lineHeight
+  troika.letterSpacing = props.letterSpacing
+  troika.textAlign = props.textAlign
+  troika.font = props.font
+  troika.anchorX = props.anchorX
+  troika.anchorY = props.anchorY
+  troika.clipRect = props.clipRect
+  troika.depthOffset = props.depthOffset
+  troika.direction = props.direction
+  troika.overflowWrap = props.overflowWrap
+  troika.whiteSpace = props.whiteSpace
+  troika.outlineWidth = props.outlineWidth
+  troika.outlineOffsetX = props.outlineOffsetX
+  troika.outlineOffsetY = props.outlineOffsetY
+  troika.outlineBlur = props.outlineBlur
+  troika.outlineColor = props.outlineColor
+  troika.outlineOpacity = props.outlineOpacity
+  troika.strokeWidth = props.strokeWidth
+  troika.strokeColor = props.strokeColor
+  troika.strokeOpacity = props.strokeOpacity
+  troika.fillOpacity = props.fillOpacity
+  troika.sdfGlyphSize = props.sdfGlyphSize
+  troika.glyphGeometryDetail = props.glyphGeometryDetail
+
+  troika.sync(() => {
+    emit('sync', troika)
+    invalidate()
+  })
+
+  // troika only runs the sync callback (and thus invalidate) when a layout-affecting
+  // (syncable) prop changes. Non-syncable visual props such as color, outline, stroke and
+  // opacity are applied in onBeforeRender, so request a repaint unconditionally here,
+  // otherwise on-demand/manual render modes never repaint when only those props change.
+  invalidate()
+}
+
+watch([() => props, localText], syncText, { deep: true, immediate: true })
+
+onUnmounted(() => {
+  instance.value?.dispose()
+})
+</script>
+
+<template>
+  <primitive :object="instance" />
+</template>

--- a/packages/cientos/src/core/objects/index.ts
+++ b/packages/cientos/src/core/objects/index.ts
@@ -8,6 +8,7 @@ import MarchingCube from './MarchingCubes/MarchingCube.vue'
 import MarchingCubes from './MarchingCubes/MarchingCubes.vue'
 import MarchingPlane from './MarchingCubes/MarchingPlane.vue'
 import Reflector from './Reflector.vue'
+import Text from './Text.vue'
 import Text3D from './Text3D.vue'
 
 export * from './useFBO/'
@@ -22,5 +23,6 @@ export {
   MarchingCubes,
   MarchingPlane,
   Reflector,
+  Text,
   Text3D,
 }

--- a/packages/cientos/src/vite-env.d.ts
+++ b/packages/cientos/src/vite-env.d.ts
@@ -9,3 +9,14 @@ declare module '*.vue' {
 
 declare module '*.glsl' {}
 declare module '*.json' {}
+
+declare module 'troika-three-text' {
+  import type { Mesh } from 'three'
+
+  export class Text extends Mesh {
+    text: string
+    sync: (callback?: () => void) => void
+    dispose: () => void
+    [key: string]: any
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ catalogs:
     three-stdlib:
       specifier: ^2.36.1
       version: 2.36.1
+    troika-three-text:
+      specifier: ^0.52.4
+      version: 0.52.4
   typescript:
     typescript:
       specifier: ^6.0.3
@@ -878,6 +881,9 @@ importers:
       three-stdlib:
         specifier: catalog:three
         version: 2.36.1(three@0.184.0)
+      troika-three-text:
+        specifier: catalog:three
+        version: 0.52.4(three@0.184.0)
       vue:
         specifier: '>=3.5.17'
         version: 3.5.26(typescript@6.0.3)
@@ -12256,6 +12262,19 @@ packages:
   trim-trailing-lines@2.1.0:
     resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
 
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -13265,6 +13284,9 @@ packages:
     peerDependenciesMeta:
       puppeteer-core:
         optional: true
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -26629,6 +26651,20 @@ snapshots:
 
   trim-trailing-lines@2.1.0: {}
 
+  troika-three-text@0.52.4(three@0.184.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.184.0
+      troika-three-utils: 0.52.4(three@0.184.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  troika-worker-utils@0.52.0: {}
+
   trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
@@ -27856,6 +27892,8 @@ snapshots:
       - react-native-b4a
       - supports-color
       - utf-8-validate
+
+  webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalogs:
     three: ^0.184.0
     three-custom-shader-material: ^6.4.0
     three-stdlib: ^2.36.1
+    troika-three-text: ^0.52.4
   typescript:
     typescript: ^6.0.3
     vue-tsc: ^3.3.4


### PR DESCRIPTION
Refs: https://github.com/orgs/Tresjs/discussions/1441

### What

Adds a `<Text>` component to cientos for SDF text via `troika-three-text`, next to the existing extruded `<Text3D>`. Mirrors drei's `<Text3D>` / `<Text>` split.

### Why

`<Text3D>` is baked-font extruded geometry only, so no kerning, ligatures, RTL, or unicode fallback. SDF text covers labels, UI, and multilingual content from real font files. The only way to get this before was the manual `<primitive>` pattern from `apps/docs/content/3.api/5.advanced/primitives.md`, where you set props and handle disposal by hand. This component does `.sync()` and disposal for you.

### How

New `packages/cientos/src/core/objects/Text.vue`, built the same way as `Text3D.vue` (`<script setup>`, props via `withDefaults`, text from prop or slot, `defineExpose({ instance })`).

Owns the troika `Text` instance, calls `instance.sync(() => { invalidate(); emit('sync', instance) })` on prop changes, disposes on unmount.

Props follow drei's `<Text>`, defaults `anchor-x="center"`, `anchor-y="middle"`, `font-size=1`, `sdf-glyph-size=64`.

Exported from `src/core/objects/index.ts`. Also updated the primitives doc to point at `<Text>`.

### Dependency

Adds `troika-three-text` as a [catalog dep / optionalDependency, per the issue]. Wasn't a cientos dep before. drei depends on it directly.

### Usage

```vue
<script setup lang="ts">
import { Text } from '@tresjs/cientos'
</script>

<template>
  <TresCanvas>
    <Text text="Hello TresJS" font="/fonts/Inter.woff" :font-size="0.5" anchor-x="center" :max-width="4" />
  </TresCanvas>
</template>
```

### Included

- [x] `Text.vue` with typed props/emits and JSDoc
- [x] Export in `src/core/objects/index.ts`
- [x] Playground demo + route (wrapping, anchoring, outline, a non-Latin string)
- [x] Docs page with a short "Text3D vs Text" note, plus updated primitives example
- [x] Vitest unit test
- [x] test / lint / typecheck / build green


### Notes for reviewers

- The dependency question (catalog dep vs optionalDependency) is the one thing I'd like confirmed.
- Prop names follow drei on purpose for familiarity, happy to rename to cientos conventions.