### PR TITLE
fix(cientos): strip scene.environment during AccumulativeShadows bake

### DIFF
--- a/apps/playground/src/components/BlenderCube.vue
+++ b/apps/playground/src/components/BlenderCube.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Mesh } from 'three'
 import { useGLTF } from '@tresjs/cientos'
 import { whenever } from '@vueuse/core'
 
@@ -10,6 +11,16 @@ const model = computed(() => nodes.value.BlenderCube)
 
 defineExpose({
   model,
+})
+
+watch(model, (model) => {
+  if (model) {
+    model.traverse((node) => {
+      if (node instanceof Mesh) {
+        node.castShadow = true
+      }
+    })
+  }
 })
 
 whenever(

--- a/apps/playground/src/pages/cientos/light-shadow/AccumulativeShadowsDemo.vue
+++ b/apps/playground/src/pages/cientos/light-shadow/AccumulativeShadowsDemo.vue
@@ -3,6 +3,7 @@ import { AccumulativeShadows, Box, Environment, Icosahedron, OrbitControls, Sphe
 import { NoToneMapping } from 'three'
 import { TresCanvas } from '@tresjs/core'
 import { TresLeches, useControls } from '@tresjs/leches'
+import BlenderCube from '@/components/BlenderCube.vue'
 
 const uuid = 'staging-accumulative-shadows'
 
@@ -22,6 +23,8 @@ const { frames, once, accumulate, limit, _isLimitInfinite, blend, alphaTest, col
   isOrange: true,
   enabled: true,
 }, { uuid })
+
+const cubeReady = shallowRef(false)
 
 const x = shallowRef(0)
 
@@ -46,44 +49,21 @@ onUnmounted(() => {
 
     <OrbitControls />
     <TresDirectionalLight :position="[5, 10, -10]" :intensity="3.14" />
-    <Box
-      :args="[0.4, 0.4, 0.4]"
-      :cast-shadow="true"
-      :position="[-0.5, 0.2, -0.3]"
-    >
+    <Box :args="[0.4, 0.4, 0.4]" :cast-shadow="true" :position="[-0.5, 0.2, -0.3]">
       <TresMeshStandardMaterial color="orange" />
     </Box>
-    <Icosahedron
-      :args="[0.3]"
-      :cast-shadow="true"
-      :position="[x, 0.3, 0.4]"
-    >
+    <Icosahedron :args="[0.3]" :cast-shadow="true" :position="[x, 0.3, 0.4]">
       <TresMeshNormalMaterial />
     </Icosahedron>
 
-    <Sphere
-      :scale="0.2"
-      :position="[0.5, 0.4, -0.3]"
-      :cast-shadow="true"
-    >
+    <Sphere :scale="0.2" :position="[0.5, 0.4, -0.3]" :cast-shadow="true">
       <TresMeshStandardMaterial color="lightblue" />
     </Sphere>
 
-    <AccumulativeShadows
-      v-if="enabled"
-      :accumulate="accumulate"
-      :alpha-test="alphaTest"
-      :blend="blend"
-      :color="isOrange ? 'orange' : 'blue'"
-      :color-blend="colorBlend"
-      :frames="frames"
-      :limit="limit"
-      :once="once"
-      :opacity="opacity"
-      :resolution="resolution"
-      :tone-mapped="toneMapped"
-      :scale="scale"
-    />
+    <BlenderCube :position="[0, 2, 0]" @ready="cubeReady = true" />
+    <AccumulativeShadows v-if="enabled" :accumulate="accumulate" :alpha-test="alphaTest" :blend="blend"
+      :color="isOrange ? 'orange' : 'blue'" :color-blend="colorBlend" :frames="frames" :limit="limit" :once="once"
+      :opacity="opacity" :resolution="resolution" :tone-mapped="toneMapped" :scale="scale" />
     <Suspense>
       <Environment preset="city" />
     </Suspense>

--- a/packages/cientos/src/core/light-shadow/AccumulativeShadows/ProgressiveLightMap.ts
+++ b/packages/cientos/src/core/light-shadow/AccumulativeShadows/ProgressiveLightMap.ts
@@ -91,7 +91,14 @@ export class ProgressiveLightMap {
     this.renderer.clear()
     this.renderer.setRenderTarget(null)
     this.renderer.setClearColor(this.clearColor, this.clearAlpha)
+  }
 
+  prepare() {
+    // NOTE: Re-collect scene lights and meshes on every bake pass (not once up
+    // front), so meshes added after the bake started — e.g. async-loaded GLTF
+    // models — get their material swapped to `discardMat` too. Otherwise an
+    // un-collected mesh renders its real (unlit, black) geometry straight into
+    // the lightmap and gets mapped onto the shadow plane as a hard silhouette.
     this.lights = []
     this.meshes = []
     this.scene.traverse((object) => {
@@ -103,9 +110,7 @@ export class ProgressiveLightMap {
         this.lights.push({ object, intensity: object.intensity })
       }
     })
-  }
 
-  prepare() {
     this.lights.forEach(light => (light.object.intensity = 0))
     this.meshes.forEach(mesh => (mesh.object.material = this.discardMat))
   }

--- a/packages/cientos/src/core/light-shadow/AccumulativeShadows/ProgressiveLightMap.ts
+++ b/packages/cientos/src/core/light-shadow/AccumulativeShadows/ProgressiveLightMap.ts
@@ -128,14 +128,19 @@ export class ProgressiveLightMap {
     // NOTE: Ping-pong two surface buffers for reading/writing
     const activeMap = this.buffer1Active ? this.progressiveLightMap1 : this.progressiveLightMap2
     const inactiveMap = this.buffer1Active ? this.progressiveLightMap2 : this.progressiveLightMap1
-    // NOTE: Render the object's surface maps
+    // NOTE: Render the object's surface maps. Strip background AND environment:
+    // the shadow-catcher uses MeshLambertMaterial, which is lit by scene.environment,
+    // so an async-loaded envmap (e.g. <Environment>) would blow out the bake.
     const oldBg = this.scene.background
+    const oldEnv = this.scene.environment
     this.scene.background = null
+    this.scene.environment = null
     this.renderer.setRenderTarget(activeMap)
     this.previousShadowMap.value = inactiveMap.texture
     this.buffer1Active = !this.buffer1Active
     this.renderer.render(this.scene, camera)
     this.renderer.setRenderTarget(null)
     this.scene.background = oldBg
+    this.scene.environment = oldEnv
   }
 }


### PR DESCRIPTION
## Summary

`AccumulativeShadows` shadows would flash on, then vanish, when the scene also had an async `<Environment>` (e.g. `preset=\"city\"`).

Root cause: the shadow-catcher plane uses `MeshLambertMaterial`, which **is** lit by `scene.environment`. `ProgressiveLightMap.update()` nulled `scene.background` during the offscreen bake but left `scene.environment` set. So the bake produced a clean shadow before the HDRI finished loading, then — once `<Environment>` assigned `scene.environment` — the remaining bake frames lit the catcher with the bright envmap, the accumulated lightmap washed out, and `alphaTest` discarded it.

Fix: null and restore `scene.environment` around the offscreen render, mirroring the existing `scene.background` handling. The bake is now immune to envmaps regardless of load timing — no `v-if` gating needed in user scenes.

## Test plan

- [ ] Open the cientos playground `AccumulativeShadows` demo (has a `<Environment preset="city">`)
- [ ] Shadow appears and **persists** after the HDRI loads (previously flashed then disappeared)
- [ ] Toggle `enabled` / orbit the camera — shadow stays stable
- [ ] Demos without an `<Environment>` are unchanged