### PR TITLE
fix(useCamera): shallow ref

### DIFF
--- a/packages/core/src/composables/useCamera/index.ts
+++ b/packages/core/src/composables/useCamera/index.ts
@@ -1,42 +1,42 @@
-import type { TresContext } from "../useTresContextProvider";
+import type { TresContext } from '../useTresContextProvider'
 
-import type { ComputedRef, ShallowRef } from "vue";
-import { computed, shallowRef, triggerRef, watchEffect } from "vue";
-import { isCamera, isPerspectiveCamera } from "../../utils/is";
-import type { TresCamera } from "../../types";
+import type { ComputedRef, ShallowRef } from 'vue'
+import { computed, shallowRef, triggerRef, watchEffect } from 'vue'
+import { isCamera, isPerspectiveCamera } from '../../utils/is'
+import type { TresCamera } from '../../types'
 
 /**
  * Interface for the return value of the useCamera composable
  */
 export interface UseCameraReturn {
-  activeCamera: ComputedRef<TresCamera>;
+  activeCamera: ComputedRef<TresCamera>
   /**
    * The list of cameras
    */
-  cameras: ShallowRef<TresCamera[]>;
+  cameras: ShallowRef<TresCamera[]>
   /**
    * Register a camera
    * @param camera - The camera to register
    * @param active - Whether to set the camera as active
    */
-  registerCamera: (camera: TresCamera, active?: boolean) => void;
+  registerCamera: (camera: TresCamera, active?: boolean) => void
   /**
    * Deregister a camera
    * @param camera - The camera to deregister
    */
-  deregisterCamera: (camera: TresCamera) => void;
+  deregisterCamera: (camera: TresCamera) => void
   /**
    * Set the active camera
    * @param cameraOrUuid - The camera or its UUID to set as active
    */
-  setActiveCamera: (cameraOrUuid: string | TresCamera) => void;
+  setActiveCamera: (cameraOrUuid: string | TresCamera) => void
 }
 
 /**
  * Interface for the parameters of the useCamera composable
  */
 interface UseCameraParams {
-  sizes: TresContext["sizes"];
+  sizes: TresContext['sizes']
 }
 
 /**
@@ -46,8 +46,8 @@ interface UseCameraParams {
  * @returns The camera management functions and state
  */
 export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn => {
-  const cameras = shallowRef<TresCamera[]>([]);
-  const activeCamera = computed<TresCamera>(() => cameras.value[0]); // the first camera is used to make sure there is always one camera active
+  const cameras = shallowRef<TresCamera[]>([])
+  const activeCamera = computed<TresCamera>(() => cameras.value[0]) // the first camera is used to make sure there is always one camera active
 
   /**
    * Set the active camera
@@ -56,15 +56,15 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
   const setActiveCamera = (cameraOrUuid: string | TresCamera) => {
     const camera = isCamera(cameraOrUuid)
       ? cameraOrUuid
-      : cameras.value.find((camera: TresCamera) => camera.uuid === cameraOrUuid);
+      : cameras.value.find((camera: TresCamera) => camera.uuid === cameraOrUuid)
 
     if (!camera) {
-      return;
+      return
     }
 
-    const otherCameras = cameras.value.filter(({ uuid }) => uuid !== camera.uuid);
-    cameras.value = [camera, ...otherCameras];
-  };
+    const otherCameras = cameras.value.filter(({ uuid }) => uuid !== camera.uuid)
+    cameras.value = [camera, ...otherCameras]
+  }
 
   /**
    * Register a camera
@@ -73,23 +73,23 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
    */
   const registerCamera = (camera: TresCamera, active = false): void => {
     if (cameras.value.some(({ uuid }) => uuid === camera.uuid)) {
-      return;
+      return
     }
-    cameras.value.push(camera);
-    triggerRef(cameras);
+    cameras.value.push(camera)
+    triggerRef(cameras)
 
     if (active) {
-      setActiveCamera(camera.uuid);
+      setActiveCamera(camera.uuid)
     }
-  };
+  }
 
   /**
    * Deregister a camera
    * @param camera - The camera to deregister
    */
   const deregisterCamera = (camera: TresCamera): void => {
-    cameras.value = cameras.value.filter(({ uuid }) => uuid !== camera.uuid);
-  };
+    cameras.value = cameras.value.filter(({ uuid }) => uuid !== camera.uuid)
+  }
 
   /**
    * Update camera aspect ratios when the window size changes
@@ -98,12 +98,12 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
     if (sizes.aspectRatio.value) {
       cameras.value.forEach((camera: TresCamera) => {
         if (isPerspectiveCamera(camera)) {
-          camera.aspect = sizes.aspectRatio.value;
-          camera.updateProjectionMatrix();
+          camera.aspect = sizes.aspectRatio.value
+          camera.updateProjectionMatrix()
         }
-      });
+      })
     }
-  });
+  })
 
   return {
     activeCamera,
@@ -111,5 +111,5 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
     registerCamera,
     deregisterCamera,
     setActiveCamera,
-  };
-};
+  }
+}

--- a/packages/core/src/composables/useCamera/index.ts
+++ b/packages/core/src/composables/useCamera/index.ts
@@ -1,43 +1,42 @@
-import type { TresContext } from '../useTresContextProvider'
+import type { TresContext } from "../useTresContextProvider";
 
-import type { ComputedRef, Ref } from 'vue'
-import { computed, ref, watchEffect } from 'vue'
-import { isCamera, isPerspectiveCamera } from '../../utils/is'
-import type { TresCamera } from '../../types'
+import type { ComputedRef, ShallowRef } from "vue";
+import { computed, shallowRef, triggerRef, watchEffect } from "vue";
+import { isCamera, isPerspectiveCamera } from "../../utils/is";
+import type { TresCamera } from "../../types";
 
 /**
  * Interface for the return value of the useCamera composable
  */
 export interface UseCameraReturn {
-
-  activeCamera: ComputedRef<TresCamera>
+  activeCamera: ComputedRef<TresCamera>;
   /**
    * The list of cameras
    */
-  cameras: Ref<TresCamera[]>
+  cameras: ShallowRef<TresCamera[]>;
   /**
    * Register a camera
    * @param camera - The camera to register
    * @param active - Whether to set the camera as active
    */
-  registerCamera: (camera: TresCamera, active?: boolean) => void
+  registerCamera: (camera: TresCamera, active?: boolean) => void;
   /**
    * Deregister a camera
    * @param camera - The camera to deregister
    */
-  deregisterCamera: (camera: TresCamera) => void
+  deregisterCamera: (camera: TresCamera) => void;
   /**
    * Set the active camera
    * @param cameraOrUuid - The camera or its UUID to set as active
    */
-  setActiveCamera: (cameraOrUuid: string | TresCamera) => void
+  setActiveCamera: (cameraOrUuid: string | TresCamera) => void;
 }
 
 /**
  * Interface for the parameters of the useCamera composable
  */
 interface UseCameraParams {
-  sizes: TresContext['sizes']
+  sizes: TresContext["sizes"];
 }
 
 /**
@@ -47,8 +46,8 @@ interface UseCameraParams {
  * @returns The camera management functions and state
  */
 export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn => {
-  const cameras = ref<TresCamera[]>([])
-  const activeCamera = computed<TresCamera>(() => cameras.value[0]) // the first camera is used to make sure there is always one camera active
+  const cameras = shallowRef<TresCamera[]>([]);
+  const activeCamera = computed<TresCamera>(() => cameras.value[0]); // the first camera is used to make sure there is always one camera active
 
   /**
    * Set the active camera
@@ -57,13 +56,15 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
   const setActiveCamera = (cameraOrUuid: string | TresCamera) => {
     const camera = isCamera(cameraOrUuid)
       ? cameraOrUuid
-      : cameras.value.find((camera: TresCamera) => camera.uuid === cameraOrUuid)
+      : cameras.value.find((camera: TresCamera) => camera.uuid === cameraOrUuid);
 
-    if (!camera) { return }
+    if (!camera) {
+      return;
+    }
 
-    const otherCameras = cameras.value.filter(({ uuid }) => uuid !== camera.uuid)
-    cameras.value = [camera, ...otherCameras]
-  }
+    const otherCameras = cameras.value.filter(({ uuid }) => uuid !== camera.uuid);
+    cameras.value = [camera, ...otherCameras];
+  };
 
   /**
    * Register a camera
@@ -71,21 +72,24 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
    * @param active - Whether to set the camera as active
    */
   const registerCamera = (camera: TresCamera, active = false): void => {
-    if (cameras.value.some(({ uuid }) => uuid === camera.uuid)) { return }
-    cameras.value.push(camera)
+    if (cameras.value.some(({ uuid }) => uuid === camera.uuid)) {
+      return;
+    }
+    cameras.value.push(camera);
+    triggerRef(cameras);
 
     if (active) {
-      setActiveCamera(camera.uuid)
+      setActiveCamera(camera.uuid);
     }
-  }
+  };
 
   /**
    * Deregister a camera
    * @param camera - The camera to deregister
    */
   const deregisterCamera = (camera: TresCamera): void => {
-    cameras.value = cameras.value.filter(({ uuid }) => uuid !== camera.uuid)
-  }
+    cameras.value = cameras.value.filter(({ uuid }) => uuid !== camera.uuid);
+  };
 
   /**
    * Update camera aspect ratios when the window size changes
@@ -94,12 +98,12 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
     if (sizes.aspectRatio.value) {
       cameras.value.forEach((camera: TresCamera) => {
         if (isPerspectiveCamera(camera)) {
-          camera.aspect = sizes.aspectRatio.value
-          camera.updateProjectionMatrix()
+          camera.aspect = sizes.aspectRatio.value;
+          camera.updateProjectionMatrix();
         }
-      })
+      });
     }
-  })
+  });
 
   return {
     activeCamera,
@@ -107,5 +111,5 @@ export const useCameraManager = ({ sizes }: UseCameraParams): UseCameraReturn =>
     registerCamera,
     deregisterCamera,
     setActiveCamera,
-  }
-}
+  };
+};


### PR DESCRIPTION
found this by accident, it required me to use `toRaw()` in some places to avoid weird bugs.

I could be wrong about the fix as I don't know the rest of the codebase but since `cameras` isn't exposed, this should be fine and better for performance unless camera properties can be changed at runtime, in that case, this will break stuff