### PR TITLE
feat(cli): scaffold @tresjs/cli multi-command shell

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -51,6 +51,7 @@
       },
       "tooling": {
         "projects": [
+          "@tresjs/cli",
           "@tresjs/eslint-config",
           "@tresjs/leches"
         ]

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present, (alvarosabu) Alvaro Saburido and Tres contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,33 @@
+# @tresjs/cli
+
+> CLI for TresJS projects
+
+## Installation
+
+```bash
+pnpm i @tresjs/cli
+```
+
+## Usage
+
+```bash
+tres --help
+```
+
+Or without installing:
+
+```bash
+npx @tresjs/cli --help
+```
+
+### Build
+
+To build the package run:
+
+```bash
+pnpm run build
+```
+
+## License
+
+[MIT](/LICENSE)

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,0 +1,5 @@
+import { tresLintConfig } from '@tresjs/eslint-config'
+
+export default tresLintConfig({
+  ignores: ['**/node_modules/**', 'dist', 'README.md'],
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@tresjs/cli",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CLI for TresJS projects",
+  "author": "Alvaro Saburido <hola@alvarosaburido.dev> (https://github.com/alvarosabu/)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Tresjs/tres.git",
+    "directory": "packages/cli"
+  },
+  "keywords": [
+    "vue",
+    "3d",
+    "threejs",
+    "tresjs",
+    "cli",
+    "gltf"
+  ],
+  "bin": {
+    "tres": "./dist/index.mjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "commander": "catalog:",
+    "kolorist": "catalog:utils"
+  },
+  "devDependencies": {
+    "@tresjs/eslint-config": "workspace:*",
+    "@types/node": "catalog:node",
+    "tsdown": "catalog:build",
+    "typescript": "catalog:typescript",
+    "vitest": "catalog:testing"
+  }
+}

--- a/packages/cli/src/banner.ts
+++ b/packages/cli/src/banner.ts
@@ -1,0 +1,9 @@
+import { bold, gray, lightGreen, yellow } from 'kolorist'
+
+/**
+ * Brand mark shared with `create-tres`: three shapes for "Tres".
+ * kolorist no-ops when NO_COLOR is set or stdout is not a TTY.
+ */
+export function banner(): string {
+  return `${lightGreen('▲')} ${gray('■')} ${yellow('●')} ${bold('Tres')}`
+}

--- a/packages/cli/src/commands/banana.ts
+++ b/packages/cli/src/commands/banana.ts
@@ -1,0 +1,8 @@
+import type { CommandHandler } from '../registry'
+
+const banana: CommandHandler = function (options: { count: number }) {
+  // eslint-disable-next-line no-console
+  console.log('🍌'.repeat(options.count))
+}
+
+export default banana

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,39 @@
+import type { CommandDefinition } from './registry'
+import { createRequire } from 'node:module'
+import { Command } from 'commander'
+import { banner } from './banner'
+import { defineCommand, registerCommands } from './registry'
+
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json') as { version: string }
+
+const commands: CommandDefinition[] = [
+  defineCommand({
+    name: 'banana',
+    description: 'Print bananas. Smoke-tests the command registry end to end.',
+    setup: cmd => cmd.option('-c, --count <n>', 'how many bananas', v => Number.parseInt(v, 10), 1),
+    load: async () => (await import('./commands/banana')).default,
+  }),
+]
+
+const program = new Command()
+
+program
+  .name('tres')
+  .description('CLI for TresJS projects')
+  .version(pkg.version)
+  .addHelpText('beforeAll', `\n${banner()}\n`)
+
+registerCommands(program, commands)
+
+async function main() {
+  try {
+    await program.parseAsync(process.argv)
+  }
+  catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -1,0 +1,163 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { detectProject } from './project'
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await realpath(await mkdtemp(join(tmpdir(), 'tresjs-cli-')))
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('detectProject', () => {
+  it('walks up from a nested cwd to find the nearest package.json as root', async () => {
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'root-pkg' }))
+    const nested = join(tempDir, 'a', 'b', 'c')
+    await mkdir(nested, { recursive: true })
+
+    const info = await detectProject(nested)
+
+    expect(info.root).toBe(tempDir)
+  })
+
+  it('returns root: cwd and null/empty fields when no package.json exists up-tree', async () => {
+    const info = await detectProject(tempDir)
+
+    expect(info.root).toBe(tempDir)
+    expect(info.packageManager).toBeNull()
+    expect(info.framework).toBeNull()
+    expect(info.configFiles).toEqual({})
+    expect(info.versions).toEqual({})
+  })
+
+  it.each([
+    ['pnpm-lock.yaml', 'pnpm'],
+    ['yarn.lock', 'yarn'],
+    ['bun.lockb', 'bun'],
+    ['package-lock.json', 'npm'],
+  ] as const)('maps %s to packageManager %s', async (lockfile, manager) => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+    await writeFile(join(tempDir, lockfile), '')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.packageManager).toBe(manager)
+  })
+
+  it('returns null packageManager when no lockfile is present', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.packageManager).toBeNull()
+  })
+
+  it('prefers pnpm, then yarn, then bun, then npm when multiple lockfiles exist', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+    await writeFile(join(tempDir, 'pnpm-lock.yaml'), '')
+    await writeFile(join(tempDir, 'yarn.lock'), '')
+    await writeFile(join(tempDir, 'bun.lockb'), '')
+    await writeFile(join(tempDir, 'package-lock.json'), '')
+
+    expect((await detectProject(tempDir)).packageManager).toBe('pnpm')
+
+    await rm(join(tempDir, 'pnpm-lock.yaml'))
+    expect((await detectProject(tempDir)).packageManager).toBe('yarn')
+
+    await rm(join(tempDir, 'yarn.lock'))
+    expect((await detectProject(tempDir)).packageManager).toBe('bun')
+
+    await rm(join(tempDir, 'bun.lockb'))
+    expect((await detectProject(tempDir)).packageManager).toBe('npm')
+  })
+
+  it('detects nuxt from a dependency even without a config file', async () => {
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ dependencies: { nuxt: '^3.0.0' } }))
+
+    const info = await detectProject(tempDir)
+
+    expect(info.framework).toBe('nuxt')
+    expect('nuxt' in info.configFiles).toBe(false)
+  })
+
+  it('detects vite when only a vite config file is present', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+    await writeFile(join(tempDir, 'vite.config.mts'), '')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.framework).toBe('vite')
+    expect(info.configFiles.vite).toBe(join(tempDir, 'vite.config.mts'))
+    expect('nuxt' in info.configFiles).toBe(false)
+  })
+
+  it('picks nuxt over vite when both a nuxt and a vite config file are present', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+    await writeFile(join(tempDir, 'nuxt.config.ts'), '')
+    await writeFile(join(tempDir, 'vite.config.ts'), '')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.framework).toBe('nuxt')
+    expect(info.configFiles.nuxt).toBe(join(tempDir, 'nuxt.config.ts'))
+    expect(info.configFiles.vite).toBe(join(tempDir, 'vite.config.ts'))
+  })
+
+  it('returns null framework and omits configFiles keys when nothing matches', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.framework).toBeNull()
+    expect('vite' in info.configFiles).toBe(false)
+    expect('nuxt' in info.configFiles).toBe(false)
+    expect('tsconfig' in info.configFiles).toBe(false)
+  })
+
+  it('records an absolute tsconfig path when present', async () => {
+    await writeFile(join(tempDir, 'package.json'), '{}')
+    await writeFile(join(tempDir, 'tsconfig.json'), '{}')
+
+    const info = await detectProject(tempDir)
+
+    expect(info.configFiles.tsconfig).toBe(join(tempDir, 'tsconfig.json'))
+  })
+
+  it('collects versions for three and @tresjs/* packages from both dependency blocks, ignoring the rest', async () => {
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: {
+        'three': '^0.180.0',
+        '@tresjs/core': 'workspace:*',
+        'vue': '^3.5.0',
+      },
+      devDependencies: {
+        '@tresjs/cientos': 'catalog:',
+        'typescript': '^5.0.0',
+      },
+    }))
+
+    const info = await detectProject(tempDir)
+
+    expect(info.versions).toEqual({
+      'three': '^0.180.0',
+      '@tresjs/core': 'workspace:*',
+      '@tresjs/cientos': 'catalog:',
+    })
+  })
+
+  it('prefers the dependencies range over devDependencies on a name clash', async () => {
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({
+      dependencies: { three: '^0.180.0' },
+      devDependencies: { three: '^0.170.0' },
+    }))
+
+    const info = await detectProject(tempDir)
+
+    expect(info.versions.three).toBe('^0.180.0')
+  })
+})

--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -38,6 +38,7 @@ describe('detectProject', () => {
   it.each([
     ['pnpm-lock.yaml', 'pnpm'],
     ['yarn.lock', 'yarn'],
+    ['bun.lock', 'bun'],
     ['bun.lockb', 'bun'],
     ['package-lock.json', 'npm'],
   ] as const)('maps %s to packageManager %s', async (lockfile, manager) => {
@@ -61,7 +62,7 @@ describe('detectProject', () => {
     await writeFile(join(tempDir, 'package.json'), '{}')
     await writeFile(join(tempDir, 'pnpm-lock.yaml'), '')
     await writeFile(join(tempDir, 'yarn.lock'), '')
-    await writeFile(join(tempDir, 'bun.lockb'), '')
+    await writeFile(join(tempDir, 'bun.lock'), '')
     await writeFile(join(tempDir, 'package-lock.json'), '')
 
     expect((await detectProject(tempDir)).packageManager).toBe('pnpm')
@@ -72,7 +73,7 @@ describe('detectProject', () => {
     await rm(join(tempDir, 'yarn.lock'))
     expect((await detectProject(tempDir)).packageManager).toBe('bun')
 
-    await rm(join(tempDir, 'bun.lockb'))
+    await rm(join(tempDir, 'bun.lock'))
     expect((await detectProject(tempDir)).packageManager).toBe('npm')
   })
 

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,0 +1,160 @@
+import { readFile, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+
+export interface ProjectInfo {
+  /** Nearest dir up-tree containing package.json (or cwd, if none found). */
+  root: string
+  packageManager: 'pnpm' | 'npm' | 'yarn' | 'bun' | null
+  framework: 'nuxt' | 'vite' | null
+  configFiles: { vite?: string, nuxt?: string, tsconfig?: string }
+  /** Declared ranges for `three` and `@tresjs/*` deps, as written in package.json. */
+  versions: Record<string, string>
+}
+
+interface PackageJsonShape {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const LOCKFILE_MANAGERS: Array<[file: string, manager: NonNullable<ProjectInfo['packageManager']>]> = [
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['bun.lockb', 'bun'],
+  ['package-lock.json', 'npm'],
+]
+
+const NUXT_CONFIG_CANDIDATES = ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs']
+const VITE_CONFIG_CANDIDATES = ['vite.config.ts', 'vite.config.js', 'vite.config.mts', 'vite.config.mjs']
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+async function findRoot(cwd: string): Promise<string | null> {
+  let dir = cwd
+
+  while (true) {
+    if (await fileExists(join(dir, 'package.json'))) {
+      return dir
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      return null
+    }
+    dir = parent
+  }
+}
+
+async function readPackageJson(root: string): Promise<PackageJsonShape> {
+  try {
+    const content = await readFile(join(root, 'package.json'), 'utf-8')
+    return JSON.parse(content) as PackageJsonShape
+  }
+  catch {
+    // A missing file and a malformed one both land here and are treated as empty.
+    // `doctor` will likely want to tell those apart and surface "unparseable
+    // package.json" as its own diagnostic instead of silently reporting "no deps".
+    return {}
+  }
+}
+
+async function detectPackageManager(root: string): Promise<ProjectInfo['packageManager']> {
+  for (const [file, manager] of LOCKFILE_MANAGERS) {
+    if (await fileExists(join(root, file))) {
+      return manager
+    }
+  }
+  return null
+}
+
+async function findFirstExisting(root: string, candidates: string[]): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    const path = join(root, candidate)
+    if (await fileExists(path)) {
+      return path
+    }
+  }
+  return undefined
+}
+
+async function detectConfigFiles(root: string): Promise<ProjectInfo['configFiles']> {
+  const configFiles: ProjectInfo['configFiles'] = {}
+
+  const nuxt = await findFirstExisting(root, NUXT_CONFIG_CANDIDATES)
+  if (nuxt) {
+    configFiles.nuxt = nuxt
+  }
+
+  const vite = await findFirstExisting(root, VITE_CONFIG_CANDIDATES)
+  if (vite) {
+    configFiles.vite = vite
+  }
+
+  const tsconfig = join(root, 'tsconfig.json')
+  if (await fileExists(tsconfig)) {
+    configFiles.tsconfig = tsconfig
+  }
+
+  return configFiles
+}
+
+function hasDependency(pkg: PackageJsonShape, name: string): boolean {
+  return Boolean(pkg.dependencies?.[name] || pkg.devDependencies?.[name])
+}
+
+function detectFramework(pkg: PackageJsonShape, configFiles: ProjectInfo['configFiles']): ProjectInfo['framework'] {
+  // Nuxt wins when both match, since a Nuxt project also has Vite underneath.
+  if (hasDependency(pkg, 'nuxt') || configFiles.nuxt) {
+    return 'nuxt'
+  }
+  if (configFiles.vite) {
+    return 'vite'
+  }
+  return null
+}
+
+function detectVersions(pkg: PackageJsonShape): Record<string, string> {
+  const versions: Record<string, string> = {}
+  // On a name clash between blocks, the runtime dependency wins over devDependencies.
+  const deps = { ...pkg.devDependencies, ...pkg.dependencies }
+
+  for (const [name, range] of Object.entries(deps)) {
+    if (name === 'three' || name.startsWith('@tresjs/')) {
+      versions[name] = range
+    }
+  }
+
+  return versions
+}
+
+export async function detectProject(cwd: string = process.cwd()): Promise<ProjectInfo> {
+  const resolvedCwd = resolve(cwd)
+  const root = await findRoot(resolvedCwd)
+
+  if (!root) {
+    return {
+      root: resolvedCwd,
+      packageManager: null,
+      framework: null,
+      configFiles: {},
+      versions: {},
+    }
+  }
+
+  const pkg = await readPackageJson(root)
+  const configFiles = await detectConfigFiles(root)
+
+  return {
+    root,
+    packageManager: await detectPackageManager(root),
+    framework: detectFramework(pkg, configFiles),
+    configFiles,
+    versions: detectVersions(pkg),
+  }
+}

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -19,6 +19,8 @@ interface PackageJsonShape {
 const LOCKFILE_MANAGERS: Array<[file: string, manager: NonNullable<ProjectInfo['packageManager']>]> = [
   ['pnpm-lock.yaml', 'pnpm'],
   ['yarn.lock', 'yarn'],
+  // `bun.lock` is the text lockfile Bun >=1.2 writes by default; `bun.lockb` is the legacy binary one.
+  ['bun.lock', 'bun'],
   ['bun.lockb', 'bun'],
   ['package-lock.json', 'npm'],
 ]

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -1,0 +1,129 @@
+import type { CommandDefinition, CommandHandler } from './registry'
+import { Command } from 'commander'
+import { describe, expect, it, vi } from 'vitest'
+import { defineCommand, registerCommands } from './registry'
+
+function createProgram(): Command {
+  const program = new Command()
+  program.name('tres').exitOverride()
+  program.configureOutput({
+    writeErr: () => {},
+    writeOut: () => {},
+  })
+  return program
+}
+
+function createLoad(handler: CommandHandler = vi.fn()) {
+  return vi.fn(async (): Promise<CommandHandler> => handler)
+}
+
+describe('defineCommand', () => {
+  it('returns the definition unchanged', () => {
+    const load = createLoad()
+    const definition = defineCommand({ name: 'foo', description: 'Foo command', load })
+
+    expect(definition).toEqual({ name: 'foo', description: 'Foo command', load })
+  })
+})
+
+describe('registerCommands', () => {
+  it('lists registered commands in --help output', () => {
+    const program = createProgram()
+    const definitions: CommandDefinition[] = [
+      defineCommand({ name: 'gltf', description: 'Transform glTF assets', load: createLoad() }),
+    ]
+
+    registerCommands(program, definitions)
+
+    const help = program.helpInformation()
+    expect(help).toContain('gltf')
+    expect(help).toContain('Transform glTF assets')
+  })
+
+  it('defers load() until the command is invoked', async () => {
+    const handler: CommandHandler = vi.fn()
+    const load = createLoad(handler)
+    const program = createProgram()
+
+    registerCommands(program, [
+      defineCommand({ name: 'doctor', description: 'Check project health', load }),
+    ])
+
+    expect(load).not.toHaveBeenCalled()
+
+    await program.parseAsync(['doctor'], { from: 'user' })
+
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs setup at registration, while load still does not', () => {
+    const setup = vi.fn()
+    const load = createLoad()
+    const program = createProgram()
+
+    registerCommands(program, [
+      defineCommand({ name: 'doctor', description: 'Check project health', setup, load }),
+    ])
+
+    expect(setup).toHaveBeenCalledTimes(1)
+    expect(load).not.toHaveBeenCalled()
+  })
+
+  it('declares an option via setup and forwards its value to the handler', async () => {
+    const handler: CommandHandler = vi.fn()
+    const load = createLoad(handler)
+    const program = createProgram()
+
+    registerCommands(program, [
+      defineCommand({
+        name: 'gltf',
+        description: 'Transform glTF assets',
+        setup: command => command.option('--out <path>', 'Output path'),
+        load,
+      }),
+    ])
+
+    await program.parseAsync(['gltf', '--out', 'dist/model.glb'], { from: 'user' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect((handler as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({ out: 'dist/model.glb' })
+  })
+
+  it('forwards a positional argument value to the handler', async () => {
+    const handler: CommandHandler = vi.fn()
+    const load = createLoad(handler)
+    const program = createProgram()
+
+    registerCommands(program, [
+      defineCommand({ name: 'demo <input>', description: 'Demo command', load }),
+    ])
+
+    await program.parseAsync(['demo', 'model.glb'], { from: 'user' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect((handler as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('model.glb')
+  })
+
+  it('exits non-zero with a message naming an unknown command', () => {
+    const program = createProgram()
+
+    registerCommands(program, [
+      defineCommand({ name: 'doctor', description: 'Check project health', load: createLoad() }),
+    ])
+
+    let error: unknown
+    try {
+      program.parse(['banana'], { from: 'user' })
+    }
+    catch (caught) {
+      error = caught
+    }
+
+    expect(error).toMatchObject({
+      code: 'commander.unknownCommand',
+      exitCode: 1,
+    })
+    expect((error as Error).message).toContain('banana')
+  })
+})

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,33 @@
+import type { Command } from 'commander'
+
+export interface CommandHandler {
+  (this: Command, ...args: any[]): void | Promise<void>
+}
+
+export interface CommandDefinition {
+  name: string
+  description: string
+  /** Declare .option()/.argument() at registration time. Must stay implementation-free — it runs on every startup. */
+  setup?: (command: Command) => void
+  /** Imported only when the command actually runs. */
+  load: () => Promise<CommandHandler>
+}
+
+export function defineCommand(definition: CommandDefinition): CommandDefinition {
+  return definition
+}
+
+export function registerCommands(program: Command, definitions: CommandDefinition[]): void {
+  for (const definition of definitions) {
+    const command = program
+      .command(definition.name)
+      .description(definition.description)
+
+    definition.setup?.(command)
+
+    command.action(async function (this: Command, ...args: any[]) {
+      const handler = await definition.load()
+      await handler.apply(this, args)
+    })
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+
+    /* Linting */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "references": [{ "path": "./tsconfig.node.json" }],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/cli/tsconfig.node.json
+++ b/packages/cli/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  },
+  "include": ["tsdown.config.mts"]
+}

--- a/packages/cli/tsdown.config.mts
+++ b/packages/cli/tsdown.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: {
+    index: './src/index.ts',
+  },
+  format: 'esm',
+  platform: 'node',
+  dts: false,
+  banner: '#!/usr/bin/env node',
+  // Pin explicitly: relying on tsdown's current default .mjs extension would
+  // silently break the `bin` entry in package.json if that default ever changes.
+  outExtensions: () => ({ js: '.mjs' }),
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ catalogs:
     camera-controls:
       specifier: ^3.1.2
       version: 3.1.2
+    commander:
+      specifier: ^15.0.0
+      version: 15.0.0
     eslint-flat-config-viewer:
       specifier: ^0.1.20
       version: 0.1.20
@@ -948,6 +951,31 @@ importers:
       vue-tsc:
         specifier: catalog:typescript
         version: 3.3.4(typescript@6.0.3)
+
+  packages/cli:
+    dependencies:
+      commander:
+        specifier: 'catalog:'
+        version: 15.0.0
+      kolorist:
+        specifier: catalog:utils
+        version: 1.8.0
+    devDependencies:
+      '@tresjs/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@types/node':
+        specifier: catalog:node
+        version: 25.9.3
+      tsdown:
+        specifier: catalog:build
+        version: 0.18.3(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(synckit@0.11.13)(typescript@6.0.3)(vue-tsc@3.2.1(typescript@6.0.3))
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vitest:
+        specifier: catalog:testing
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -13629,8 +13657,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -15455,7 +15483,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.0
       '@emnapi/runtime': 1.11.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
@@ -15520,7 +15548,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       srvx: 0.9.8
       std-env: 3.10.0
       tinyexec: 1.2.4
@@ -15721,7 +15749,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 1.0.0
       pkg-types: 2.3.1
-      semver: 7.7.4
+      semver: 7.8.4
       simple-git: 3.30.0
       sirv: 3.0.2
       structured-clone-es: 1.0.0
@@ -16034,7 +16062,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 2.1.2
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -16138,7 +16166,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 2.1.2
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       std-env: 3.10.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
@@ -16668,7 +16696,7 @@ snapshots:
       '@nuxt/kit': 3.21.8(magicast@0.5.3)
       pathe: 1.1.2
       pkg-types: 1.3.1
-      semver: 7.7.4
+      semver: 7.8.4
     transitivePeerDependencies:
       - magicast
 
@@ -16739,7 +16767,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.5
       nx: 22.4.4
-      semver: 7.7.4
+      semver: 7.8.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
@@ -16750,7 +16778,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.5
       nx: 22.7.5
-      semver: 7.7.4
+      semver: 7.8.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
@@ -16858,7 +16886,7 @@ snapshots:
       enquirer: 2.3.6
       nx: 22.7.5
       picomatch: 4.0.4
-      semver: 7.7.4
+      semver: 7.8.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -21779,10 +21807,6 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -23751,7 +23775,7 @@ snapshots:
       rollup: 4.54.0
       rollup-plugin-visualizer: 6.0.5(rolldown@1.1.1)(rollup@4.54.0)
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.4
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
@@ -26555,8 +26579,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -27720,7 +27744,7 @@ snapshots:
 
   vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.38)(esbuild@0.27.7)(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.5.38
       esbuild: 0.27.7
       vue: 3.5.38(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,6 +105,7 @@ catalog:
   '@vueuse/shared': ^14.3.0
   better-sqlite3: ^12.10.0
   camera-controls: ^3.1.2
+  commander: ^15.0.0
   eslint-flat-config-viewer: ^0.1.20
   eslint-plugin-format: ^2.0.1
   eslint-plugin-vitest-globals: ^1.6.1


### PR DESCRIPTION
Scaffolds `@tresjs/cli` (bin: `tres`) — the multi-command shell that `gltf` codegen and `doctor` will plug into.

Closes TRES-369

## What lands

- **`@tresjs/cli` package** — ESM-only, tsdown build, bin `tres` → `dist/index.mjs`, added to the nx `tooling` release group.
- **Lazy command registry** (`src/registry.ts`) — commands declare their CLI surface eagerly via a `setup?` hook, but the handler module is only imported when the command actually runs. This matters because `gltf` will pull in three.js; registering it must cost nothing when you run something else.
- **Shared project detection** (`src/project.ts`) — package manager, framework (nuxt/vite), config-file paths, and declared `@tresjs/*` + `three` versions. This is the actual justification for one CLI instead of several separate tools: `gltf`, `doctor` and a future `add` all need these same answers.
- **Brand banner** — `▲ ■ ●  Tres`, matching `create-tres`, shown on `--help` only (a banner on every invocation would corrupt piped output).
- **`banana` command** — a deliberate smoke test that exercises the registry end to end (args, options, lazy load). See open question below.

## Deliberately not here

- **No `gltf` command.** It needs the parser (TRES-368) and emitter (TRES-372). A registered command that errors at runtime is worse than no command.
- **No `doctor` command.** That's TRES-373, and it only depends on this shell — it can ship as the first genuinely useful release.
- **`"private": true`** — with `useCommitScope: false`, any `feat:` commit bumps every project in the `tooling` release group. Without this, the next release could publish a CLI to npm whose entire behaviour is printing help. Flip it when `doctor` lands.

## Test plan

```bash
pnpm install
pnpm --filter @tresjs/cli build

pnpm exec tres --help          # banner + command list
pnpm exec tres --version       # 0.0.0
pnpm exec tres banana          # 🍌
pnpm exec tres banana -c 5     # 🍌🍌🍌🍌🍌
pnpm exec tres banana --nope   # exits 1, unknown option
pnpm exec tres nope            # exits 1, unknown command

pnpm --filter @tresjs/cli test       # 22 passing
pnpm --filter @tresjs/cli lint
pnpm --filter @tresjs/cli typecheck
```

## Open questions for review

1. **Keep `banana`?** It's genuinely useful as a registry smoke test, but it's also a joke command in a published package. Remove it when `doctor` lands, or keep it permanently (in which case it wants a test)?
2. **Lockfile diff is larger than expected** — 62 lines. Adding the `packages/cli` importer is most of it, but pnpm also re-resolved some unrelated entries (semver hoisting, `fdir` optionalDeps, `rollup-plugin-visualizer`) while regenerating. Worth a glance to confirm you're happy with the churn.

## Known gaps (tracked, not blocking)

- `typecheck` passes but `tsc --noEmit` does not traverse the `tsconfig.node.json` project reference, so `tsdown.config.mts` isn't actually type-checked. Verified with an injected type error that went uncaught. The same gap exists in `packages/rapier`, so it's repo-wide rather than new here.
- `detectProject` resolves `root` to the nearest `package.json`, so running it inside a sub-package of a monorepo reports `packageManager: null` (the lockfile lives at the workspace root). Correct per spec, but `doctor` will want workspace-root awareness — worth folding into TRES-373.