### PR TITLE
chore(publish): block npm publish, verify packed specifiers

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: Build publishable packages
         run: pnpm nx run-many -p="tag:npm:public" -t=build
 
+      - name: Verify packed manifests have no catalog:/workspace: specifiers
+        run: node tools/guards/check-tarball-specifiers.mjs
+        shell: bash
+
       - name: Print Environment Info
         run: pnpm nx report
         shell: bash

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "nx run-many --target=test",
     "monocubo": "node tools/monocubo/dist/index.js",
     "sponsorkit": "sponsorkit",
+    "check:publish": "node tools/guards/check-tarball-specifiers.mjs",
     "release": "nx release --skip-publish --group=core",
     "release:version": "nx release version",
     "release:dry-run": "nx release --dry-run --skip-publish --group=core"

--- a/packages/cientos/package.json
+++ b/packages/cientos/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "dev": "cd playground/vue && pnpm dev",
     "build": "tsdown",
     "build:analyze": "ANALYZE=true tsdown",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "build": "tsdown",
     "build:analyze": "ANALYZE=true tsdown",
     "test": "vitest",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -38,6 +38,7 @@
     "dist"
   ],
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "dev": "npx @eslint/config-inspector --config eslint.config.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/leches/package.json
+++ b/packages/leches/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "build": "vite build",
     "build:analyze": "ANALYZE=true vite build",
     "preview": "vite preview",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -36,6 +36,7 @@
     "dist"
   ],
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "build": "pnpm run module:build && pnpm run client:build",
     "module:build": "nuxt-module-build prepare && nuxt-module-build build",
     "client:build": "nuxt prepare client && nuxi generate client",

--- a/packages/postprocessing/package.json
+++ b/packages/postprocessing/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "build": "tsdown",
     "build:analyze": "ANALYZE=true tsdown",
     "preview": "vite preview",

--- a/packages/rapier/CHANGELOG.md
+++ b/packages/rapier/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1 (2026-07-29)
+
+### 🩹 Fixes
+
+- **rapier:** republish with resolved dependency versions. 1.0.0 was published with `npm publish`, which leaves pnpm `catalog:` specifiers untouched, so installing it failed with `"@dimforge/rapier3d-compat@catalog:" isn't supported by any available resolver`. No source changes.
+
 # 1.0.0 (2026-07-28)
 
 ### 🚀 Features

--- a/packages/rapier/package.json
+++ b/packages/rapier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tresjs/rapier",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TresJs physics support, powered by rapier",
   "author": "Alvaro Saburido <hola@alvarosaburido.dev> (https://github.com/alvarosabu/)",
   "license": "MIT",
@@ -42,6 +42,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "node ../../tools/guards/no-npm-publish.mjs",
     "build": "tsdown",
     "build:analyze": "ANALYZE=true tsdown",
     "lint": "eslint .",

--- a/tools/guards/check-tarball-specifiers.mjs
+++ b/tools/guards/check-tarball-specifiers.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Packs every publishable workspace package and asserts the resulting manifest contains no
+ * local-only specifiers (`catalog:`, `workspace:`, `link:`, `file:`). Those must be rewritten
+ * to real versions at pack/publish time; if any survive, the release would be installable
+ * by nobody.
+ *
+ * Run: node tools/guards/check-tarball-specifiers.mjs
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const ROOT = resolve(import.meta.dirname, '../..')
+const PACKAGE_DIRS = ['packages', 'tools']
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+const BAD_SPECIFIER = /^(?:catalog:|workspace:|link:|file:)/
+
+function publishablePackages() {
+  const found = []
+  for (const parent of PACKAGE_DIRS) {
+    const parentPath = join(ROOT, parent)
+    if (!existsSync(parentPath)) { continue }
+    for (const dir of readdirSync(parentPath)) {
+      const manifestPath = join(parentPath, dir, 'package.json')
+      if (!existsSync(manifestPath)) { continue }
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+      if (manifest.private) { continue }
+      found.push({ name: manifest.name, dir: join(parentPath, dir) })
+    }
+  }
+  return found.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function packedManifest(pkg, destination) {
+  const stdout = execFileSync('pnpm', ['pack', '--pack-destination', destination], {
+    cwd: pkg.dir,
+    encoding: 'utf8',
+  })
+  const tarball = stdout.trim().split('\n').pop().trim()
+  const raw = execFileSync('tar', ['-xzOf', tarball, 'package/package.json'], { encoding: 'utf8' })
+  return JSON.parse(raw)
+}
+
+const packages = publishablePackages()
+if (!packages.length) {
+  console.error('✖ No publishable packages found — the check would pass vacuously.')
+  process.exit(1)
+}
+
+const scratch = mkdtempSync(join(tmpdir(), 'tres-tarball-check-'))
+const violations = []
+
+try {
+  for (const pkg of packages) {
+    const manifest = packedManifest(pkg, scratch)
+    for (const field of DEP_FIELDS) {
+      for (const [dep, range] of Object.entries(manifest[field] ?? {})) {
+        if (BAD_SPECIFIER.test(range)) {
+          violations.push(`${pkg.name} → ${field}.${dep} = "${range}"`)
+        }
+      }
+    }
+    console.log(`${violations.length ? '·' : '✓'} ${pkg.name}`)
+  }
+}
+finally {
+  rmSync(scratch, { recursive: true, force: true })
+}
+
+if (violations.length) {
+  console.error(`\n✖ Unresolved local specifiers in packed manifests:\n${violations.map(v => `  ${v}`).join('\n')}\n`)
+  console.error('These would ship to npm as-is and break every consumer install.')
+  process.exit(1)
+}
+
+console.log('\n✓ All publishable packages pack with resolved specifiers.')

--- a/tools/guards/no-npm-publish.mjs
+++ b/tools/guards/no-npm-publish.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * prepublishOnly guard.
+ *
+ * `npm publish` does not understand pnpm's `catalog:`/`workspace:` protocols, so publishing
+ * with it ships unresolved specifiers that break every consumer install.
+ * (@tresjs/rapier@1.0.0 shipped `"@dimforge/rapier3d-compat": "catalog:"` this way.)
+ *
+ * Escape hatch: TRES_SKIP_PUBLISH_GUARD=1
+ */
+
+const userAgent = process.env.npm_config_user_agent ?? ''
+const isPnpm = /^pnpm\//.test(userAgent)
+
+if (!isPnpm && process.env.TRES_SKIP_PUBLISH_GUARD !== '1') {
+  const pkg = process.env.npm_package_name ?? 'this package'
+  console.error(`
+✖ Refusing to publish ${pkg} with a non-pnpm client (user agent: ${userAgent || 'unknown'}).
+
+  This workspace uses pnpm catalogs. Only \`pnpm publish\` rewrites \`catalog:\` and
+  \`workspace:\` specifiers into real versions; \`npm publish\` ships them verbatim and
+  every consumer install fails with:
+
+    "<dep>@catalog:" isn't supported by any available resolver
+
+  Use instead:
+    pnpm --filter ${pkg} publish --access public
+    # or, for a full release:
+    pnpm nx release publish
+
+  Override (you had better be sure): TRES_SKIP_PUBLISH_GUARD=1
+`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Context

`@tresjs/rapier@1.0.0` shipped to npm with unresolved pnpm specifiers:

```json
"dependencies": {
  "@dimforge/rapier3d-compat": "catalog:",
  "@vueuse/core": "catalog:utils"
}
```

Every consumer install fails with `"@dimforge/rapier3d-compat@catalog:" isn't supported by any available resolver`.

Root cause: publish run [30350281214](https://github.com/Tresjs/tres/actions/runs/30350281214) failed on rapier only (`E404 PUT /@tresjs%2frapier`, no trusted publisher registered for that package name), and the release was then completed by hand with `npm publish`. npm does not understand `catalog:`/`workspace:`; only `pnpm publish` rewrites them into real versions.

All other published packages were checked and are clean. Only `@tresjs/rapier@1.0.0` is affected.

## Changes

- **`tools/guards/no-npm-publish.mjs`** — wired as `prepublishOnly` in all 7 publishable packages. Fails with an explanatory message when the publish client is not pnpm. Escape hatch: `TRES_SKIP_PUBLISH_GUARD=1`.
- **`tools/guards/check-tarball-specifiers.mjs`** — packs every non-private workspace package and fails if a tarball manifest still contains `catalog:`, `workspace:`, `link:` or `file:`. Runs in `publish.yaml` before the publish step, also available as `pnpm check:publish`.
- **`@tresjs/rapier` → 1.0.1** plus CHANGELOG entry. Republish only, no source changes.

## Verification

- `npm publish --dry-run` in `packages/rapier` → blocked, exit 1
- `pnpm --filter @tresjs/rapier publish --dry-run` → passes, `📦 @tresjs/rapier@1.0.1`
- `pnpm check:publish` → all 7 packages pass; failure path verified to list violations and exit 1, and to refuse passing vacuously when no packages are found

## Follow-up (not in this PR)

- Publish `@tresjs/rapier@1.0.1` with `pnpm --filter @tresjs/rapier publish --access public`, then `npm deprecate "@tresjs/rapier@1.0.0"`
- Register the trusted publisher for `@tresjs/rapier` on npmjs.com (repo `Tresjs/tres`, workflow `publish.yaml`) — without it, CI 404s on rapier again
