### PR TITLE
fix(rapier): isolate world gravity per Physics instance

### DIFF
--- a/packages/rapier/src/composables/useRapier.ts
+++ b/packages/rapier/src/composables/useRapier.ts
@@ -19,7 +19,9 @@ const [
     const RAPIER = await import('@dimforge/rapier3d-compat')
     await RAPIER.init()
     rapier.value = RAPIER
-    world.value = new RAPIER.World(GRAVITY)
+    // Copy: World stores the vector by reference and Physics mutates it in place,
+    // so passing the shared constant would leak gravity across every world.
+    world.value = new RAPIER.World({ ...GRAVITY })
   }
 
   const setWorld = (w: World) => {


### PR DESCRIPTION
## Summary

Rapier's `World` constructor stores the gravity vector **by reference** (`this.gravity = gravity`), and `useRapier` passed the module-level `GRAVITY` constant directly. Every `<Physics>` world therefore shared one gravity object.

`Physics.vue` mutates it in place when the `gravity` prop changes:

```ts
world.value.gravity.x = x
```

So changing gravity in one scene wrote straight into the shared constant, and every other world (already aliasing it) picked up the value. The prop default also reads `GRAVITY.x/y/z`, so even newly mounted `<Physics>` instances inherited the override.

Visible on the docs site: moving the gravity slider on [/api](https://rapier.tresjs.org/api) changed gravity in every other demo, on every page.

Fix: pass a copy at world creation, so each world owns its gravity vector.

## Test plan

- [ ] Build the package: `pnpm --filter @tresjs/rapier build`
- [ ] Run rapier-docs, drag the gravity sliders on `/api`, confirm the ball reacts
- [ ] Navigate to another demo page (e.g. `/api/rigid-body`), confirm gravity is back to the `[0, -9.81, 0]` default
- [ ] Return to `/api`, confirm the slider still drives that scene only