### PR TITLE
feat(cli): emit ready event and expose isReady on generated SFCs

### DIFF
--- a/apps/docs/content/4.cli/2.gltf.md
+++ b/apps/docs/content/4.cli/2.gltf.md
@@ -58,6 +58,7 @@ Override the named slots from the parent instead; regenerating keeps your overri
 */
 import type { Group, Mesh, MeshStandardMaterial } from 'three'
 import { useGLTF } from '@tresjs/cientos'
+import { ref, watch } from 'vue'
 
 interface ModelNodes {
   Scene: Group
@@ -79,7 +80,26 @@ defineSlots<{
 
 const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/Mug.glb', { draco: true })
 
-defineExpose({ nodes, materials })
+const emit = defineEmits<{
+  ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
+}>()
+
+const isReady = ref(false)
+watch(
+  isLoading,
+  (loading) => {
+    if (loading) {
+      isReady.value = false
+      return
+    }
+    if (isReady.value) { return }
+    isReady.value = true
+    emit('ready', { nodes: nodes.value, materials: materials.value })
+  },
+  { flush: 'post', immediate: true },
+)
+
+defineExpose({ nodes, materials, isReady })
 </script>
 
 <template>
@@ -107,6 +127,7 @@ A few things are worth pointing out:
 - **Draco is detected**, and `{ draco: true }` is passed automatically. A Draco model renders nothing without it.
 - **Lights, cameras and bones** are emitted as `<primitive :object="..." />`: their props live on the parsed object, and a bone must *be* the parsed object for skinning to work.
 - **The root `TresGroup` stays mounted** and gates its children with `v-if="!isLoading"`, so refs on it are stable.
+- **`@ready` fires once the model has loaded**, carrying `{ nodes, materials }`, and `isReady` exposes the same as a value. The event is one-shot, so the pair also covers a parent that binds after the load, and `isReady` resets if the model is ever refetched.
 ::
 
 ## Overriding a node
@@ -161,11 +182,17 @@ function paintItRed() {
 </template>
 ```
 
+::prose-note
+If you only need them the moment the model is ready, `@ready="({ nodes, materials }) => …"` hands
+you the same pair without a ref. The exposed `nodes` and `materials` are for reaching in at any
+point after.
+::
+
 ## Animated models
 
 When the model ships animation clips, the generated component also wires up
-[`useAnimations`](https://cientos.tresjs.org/api/miscellaneous/use-animations) and exposes
-`actions`, keyed by a union of the clip names:
+[`useAnimations`](https://cientos.tresjs.org/api/miscellaneous/use-animations) and hands the
+bound `actions` to `@ready`, keyed by a union of the clip names:
 
 ```ts
 type ActionName
@@ -174,21 +201,26 @@ type ActionName
     | 'Death_A'
 ```
 
+`@ready` fires once, after the clips have loaded and the mixer has bound its actions, with
+`{ nodes, materials, actions }`. No template ref, and `actions.Idle` is there to play:
+
 ```vue [App.vue]
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
 import Knight from '@/models/Knight.gen.vue'
 
-const knight = ref<InstanceType<typeof Knight>>()
-
-// actions.Idle, not actions['Idle'] — and a typo is a compile error
-onMounted(() => knight.value?.actions.Idle?.play())
+// actions.Idle, not actions['Idle'], and a typo is a compile error
 </script>
 
 <template>
-  <Knight ref="knight" />
+  <Knight @ready="({ actions }) => actions.Idle?.play()" />
 </template>
 ```
+
+Prefer the event over reaching through a ref. The mixer binds its actions a flush after the clips
+land (`useAnimations` runs `flush: 'post'` for exactly this), so a handler that reads `actions`
+too early sees them undefined. `@ready` waits for the binding; `isReady` exposes the same state
+as a value, `false` until it holds and reset on any refetch, for a parent that binds late or asks
+again later.
 
 A mixer resolves every track against a node **name**, so the CLI keeps the name of every node a
 clip drives, whatever `--slots` or `--keepnames` say. A group that exists only to be animated
@@ -242,9 +274,9 @@ The component loads each one and merges the clips into a single array, the model
 
 ```ts
 const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/Dummy.glb')
-const { state: rigMediumGeneral } = useGLTF('/models/animations/Rig_Medium_General.glb')
-const { state: rigMediumMovementBasic } = useGLTF('/models/animations/Rig_Medium_MovementBasic.glb')
-const { state: rigMediumMovementAdvanced } = useGLTF('/models/animations/Rig_Medium_MovementAdvanced.glb')
+const { state: rigMediumGeneral, isLoading: rigMediumGeneralLoading } = useGLTF('/models/animations/Rig_Medium_General.glb')
+const { state: rigMediumMovementBasic, isLoading: rigMediumMovementBasicLoading } = useGLTF('/models/animations/Rig_Medium_MovementBasic.glb')
+const { state: rigMediumMovementAdvanced, isLoading: rigMediumMovementAdvancedLoading } = useGLTF('/models/animations/Rig_Medium_MovementAdvanced.glb')
 
 const animations = computed(() => {
   // The mixer resolves every track against a node name in the rendered tree and never
@@ -268,6 +300,29 @@ and three caches the miss instead of retrying it.
 `ActionName` becomes the union across every file, and the node names the external clips drive
 survive pruning exactly like the model's own would. Each file gets its own url, inferred from
 `public/` the same way the model's is, and its own `{ draco: true }` when it is compressed.
+
+This is where `@ready` earns its place over a hand-rolled watch. Each clip file resolves on its
+own, so `actions` can populate with the first library's clips and repopulate as the others land.
+`@ready` reads every file's loading state plus the model's, and holds until all of them are in
+and the actions are bound, so a handler never fires on a half-merged `actions`:
+
+```ts
+watch(
+  () => [isLoading.value, rigMediumGeneralLoading.value, rigMediumMovementBasicLoading.value, rigMediumMovementAdvancedLoading.value, Object.keys(actions).length],
+  (signals) => {
+    // ready only when nothing is loading and the actions are bound
+    if (signals.slice(0, -1).some(Boolean) || !signals.at(-1)) {
+      isReady.value = false
+      return
+    }
+    // …emit('ready', { nodes: nodes.value, materials: materials.value, actions })
+  },
+  { flush: 'post', immediate: true },
+)
+```
+
+A watch that fired on the first non-empty `actions` would see only the General clips, and
+`actions.Jump_Start` (a MovementBasic clip) would be `undefined`. `@ready` waits for the lot.
 
 #### When two files carry the same clip name
 
@@ -400,6 +455,10 @@ import RobotInstances from '@/models/Robot.instances.gen.vue'
 The provider is found through `provide`/`inject`, so the copies can sit anywhere below it. A
 `<Robot>` rendered **outside** its provider throws with a message saying so, rather than
 rendering nothing.
+
+Each copy still emits its own `@ready` and exposes `isReady`. The provider owns the load, so the
+model reads the injected data instead of an `isLoading` of its own: ready follows the actions
+binding when the model is animated, and the nodes populating when it is not.
 
 `--instance` only batches a geometry that two or more meshes share. `--instanceall` batches
 every eligible mesh, including the ones that appear once, which pays off when the whole model is

--- a/apps/docs/content/4.cli/2.gltf.md
+++ b/apps/docs/content/4.cli/2.gltf.md
@@ -72,23 +72,24 @@ interface ModelMaterials {
   'coat': MeshStandardMaterial
 }
 
+const emit = defineEmits<{
+  ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
+}>()
+
 defineSlots<{
   Mesh?: (props: { node: Mesh, material: MeshStandardMaterial }) => any
   Mesh_1?: (props: { node: Mesh, material: MeshStandardMaterial }) => any
   Mug?: (props: { node: Group }) => any
 }>()
 
-const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/Mug.glb', { draco: true })
-
-const emit = defineEmits<{
-  ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
-}>()
+const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/Mug.glb', { draco: true })
 
 const isReady = ref(false)
 watch(
-  isLoading,
-  (loading) => {
-    if (loading) {
+  () => !isLoading.value
+    && state.value !== null,
+  (ready) => {
+    if (!ready) {
       isReady.value = false
       return
     }
@@ -127,7 +128,8 @@ A few things are worth pointing out:
 - **Draco is detected**, and `{ draco: true }` is passed automatically. A Draco model renders nothing without it.
 - **Lights, cameras and bones** are emitted as `<primitive :object="..." />`: their props live on the parsed object, and a bone must *be* the parsed object for skinning to work.
 - **The root `TresGroup` stays mounted** and gates its children with `v-if="!isLoading"`, so refs on it are stable.
-- **`@ready` fires once the model has loaded**, carrying `{ nodes, materials }`, and `isReady` exposes the same as a value. The event is one-shot, so the pair also covers a parent that binds after the load, and `isReady` resets if the model is ever refetched.
+- **`@ready` fires once per load**, carrying `{ nodes, materials }`, and `isReady` exposes the same state as a value. An event that already fired cannot be read after the fact, which is what `isReady` is for: a parent that binds late, or a state machine that wants to ask later. Refetching the model (`useGLTF` exposes `execute()`) puts `isReady` back to `false` and arms `ready` again.
+- **Readiness reads `state`, not just `isLoading`.** `isLoading` is cleared in a `finally`, so a 404 clears it exactly like a success would; `state` is only set when the load produced a scene. Without that term a failed load would call the model ready with empty `nodes` and `materials`.
 ::
 
 ## Overriding a node
@@ -201,7 +203,7 @@ type ActionName
     | 'Death_A'
 ```
 
-`@ready` fires once, after the clips have loaded and the mixer has bound its actions, with
+`@ready` fires once per load, after the clips have loaded and the mixer has bound its actions, with
 `{ nodes, materials, actions }`. No template ref, and `actions.Idle` is there to play:
 
 ```vue [App.vue]
@@ -303,15 +305,19 @@ survive pruning exactly like the model's own would. Each file gets its own url, 
 
 This is where `@ready` earns its place over a hand-rolled watch. Each clip file resolves on its
 own, so `actions` can populate with the first library's clips and repopulate as the others land.
-`@ready` reads every file's loading state plus the model's, and holds until all of them are in
-and the actions are bound, so a handler never fires on a half-merged `actions`:
+The generated gate names every condition it waits for, and holds until all of them hold:
 
 ```ts
+const isReady = ref(false)
 watch(
-  () => [isLoading.value, rigMediumGeneralLoading.value, rigMediumMovementBasicLoading.value, rigMediumMovementAdvancedLoading.value, Object.keys(actions).length],
-  (signals) => {
-    // ready only when nothing is loading and the actions are bound
-    if (signals.slice(0, -1).some(Boolean) || !signals.at(-1)) {
+  () => !isLoading.value
+    && !rigMediumGeneralLoading.value
+    && !rigMediumMovementBasicLoading.value
+    && !rigMediumMovementAdvancedLoading.value
+    && state.value !== null
+    && Object.keys(actions).length > 0,
+  (ready) => {
+    if (!ready) {
       isReady.value = false
       return
     }
@@ -323,6 +329,10 @@ watch(
 
 A watch that fired on the first non-empty `actions` would see only the General clips, and
 `actions.Jump_Start` (a MovementBasic clip) would be `undefined`. `@ready` waits for the lot.
+
+The `state` term is doing something less obvious. The actions bind against the root group, which
+stays mounted whatever the load did, so clips from a `--animations` file fill `actions` even when
+the **model** itself 404s. Without that term a rig that never arrived would still report ready.
 
 #### When two files carry the same clip name
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,14 +48,15 @@ lived in the generated file.
 
 The component declares the shape of the model it was generated from, so `node` above
 is a `Mesh` rather than an `any`, and a mesh the artist renamed turns into a type error
-at the override that used it. Animated models also get their clip names as a union:
+at the override that used it. Animated models get their clip names as a union and hand
+the bound `actions` to `@ready`, which fires once the clips are loaded and the actions
+bound (`isReady` exposes the same as a value):
 
 ```vue
-<script setup lang="ts">
-const robot = ref<InstanceType<typeof Robot>>()
-// actions.Idle, not actions['Idle'] — and a typo is a compile error
-onMounted(() => robot.value?.actions.Idle?.play())
-</script>
+<template>
+  <!-- actions.Idle, not actions['Idle'], and a typo is a compile error -->
+  <Robot @ready="({ actions }) => actions.Idle?.play()" />
+</template>
 ```
 
 | Flag | |

--- a/packages/cli/src/commands/gltf.test.ts
+++ b/packages/cli/src/commands/gltf.test.ts
@@ -247,7 +247,7 @@ describe('gltf command', () => {
       await gltf.call({} as any, model, { animations: [idle] })
 
       const generated = await readFile(join(dir, 'rig/models/Dummy.gen.vue'), 'utf-8')
-      expect(generated).toContain(`const { state: idle } = useGLTF('/clips/Idle.glb')`)
+      expect(generated).toContain(`const { state: idle, isLoading: idleLoading } = useGLTF('/clips/Idle.glb')`)
       expect(generated).toContain('    ...(idle.value?.animations ?? []),')
       expect(generated).toContain(`type ActionName\n  = | 'Idle'`)
     })

--- a/packages/cli/src/emit/instances.test.ts
+++ b/packages/cli/src/emit/instances.test.ts
@@ -53,7 +53,15 @@ describe('--instance', () => {
     const { code, instances } = await emit(repeatedGeometryGLB())
 
     expect(instances).toContain('export interface ModelContext {')
-    expect(code).toContain(`import type { ModelContext } from './Rocks.instances.gen.vue'`)
+    expect(code).toContain(`import type { ModelNodes, ModelMaterials, ModelContext } from './Rocks.instances.gen.vue'`)
+  })
+
+  it('emits ready once the provider has populated the static instanced model', async () => {
+    const { code } = await emit(repeatedGeometryGLB())
+
+    expect(code).toContain('() => Object.keys(nodes.value).length')
+    expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value })`)
+    expect(code).toContain('defineExpose({ nodes, materials, isReady })')
   })
 
   it('says so rather than rendering nothing when the model is used on its own', async () => {
@@ -233,6 +241,17 @@ describe('--instance', () => {
       expect(instances).toContain(`${'  '}animations: ComputedRef<AnimationClip[]>`)
       expect(code).toContain('const { nodes, materials, animations } = context')
       expect(code).toContain('const { actions } = useAnimations<AnimationClip, ActionName>(animations, modelRef)')
+    })
+
+    it('fires ready on bound actions alone, since the provider owns the load', async () => {
+      const { code } = await emitWithClips(repeatedGeometryGLB(), [
+        { path: 'clips/Spin.glb', glb: clipOnlyGLB('Spin', ['Rock_0']) },
+      ])
+
+      expect(code).toContain('() => Object.keys(actions).length')
+      expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value, actions })`)
+      expect(code).toContain('defineExpose({ nodes, materials, actions, isReady })')
+      expect(code).toContain(`import type { ActionName, ModelNodes, ModelMaterials, ModelContext } from './Rocks.instances.gen.vue'`)
     })
 
     it('exports the union across every file for the model half to import', async () => {

--- a/packages/cli/src/emit/instances.test.ts
+++ b/packages/cli/src/emit/instances.test.ts
@@ -53,13 +53,14 @@ describe('--instance', () => {
     const { code, instances } = await emit(repeatedGeometryGLB())
 
     expect(instances).toContain('export interface ModelContext {')
-    expect(code).toContain(`import type { ModelNodes, ModelMaterials, ModelContext } from './Rocks.instances.gen.vue'`)
+    // Sorted: perfectionist/sort-named-imports reads the generated file too.
+    expect(code).toContain(`import type { ModelContext, ModelMaterials, ModelNodes } from './Rocks.instances.gen.vue'`)
   })
 
   it('emits ready once the provider has populated the static instanced model', async () => {
     const { code } = await emit(repeatedGeometryGLB())
 
-    expect(code).toContain('() => Object.keys(nodes.value).length')
+    expect(code).toContain('  () => Object.keys(nodes.value).length > 0,')
     expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value })`)
     expect(code).toContain('defineExpose({ nodes, materials, isReady })')
   })
@@ -248,10 +249,10 @@ describe('--instance', () => {
         { path: 'clips/Spin.glb', glb: clipOnlyGLB('Spin', ['Rock_0']) },
       ])
 
-      expect(code).toContain('() => Object.keys(actions).length')
+      expect(code).toContain('  () => Object.keys(actions).length > 0,')
       expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value, actions })`)
       expect(code).toContain('defineExpose({ nodes, materials, actions, isReady })')
-      expect(code).toContain(`import type { ActionName, ModelNodes, ModelMaterials, ModelContext } from './Rocks.instances.gen.vue'`)
+      expect(code).toContain(`import type { ActionName, ModelContext, ModelMaterials, ModelNodes } from './Rocks.instances.gen.vue'`)
     })
 
     it('exports the union across every file for the model half to import', async () => {

--- a/packages/cli/src/emit/sfc.test.ts
+++ b/packages/cli/src/emit/sfc.test.ts
@@ -378,22 +378,23 @@ describe('emitSFC', () => {
         'Autumm orange': MeshStandardMaterial
       }
 
+      const emit = defineEmits<{
+        ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
+      }>()
+
       defineSlots<{
         'Body'?: (props: { node: Mesh, material: MeshStandardMaterial }) => any
         'Model-Toy-Rocket'?: (props: { node: Object3D }) => any
       }>()
 
-      const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/robot.glb')
-
-      const emit = defineEmits<{
-        ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
-      }>()
+      const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/robot.glb')
 
       const isReady = ref(false)
       watch(
-        isLoading,
-        (loading) => {
-          if (loading) {
+        () => !isLoading.value
+          && state.value !== null,
+        (ready) => {
+          if (!ready) {
             isReady.value = false
             return
           }
@@ -472,11 +473,11 @@ describe('emitSFC', () => {
       expect(code).toContain('return []')
     })
 
-    it('never destructures a state the model has no clips to put in', async () => {
+    it('never merges clips out of a state the model has none in', async () => {
       const { code } = await emitWithClips(skinnedNoClipsGLB(), [{ path: 'clips/Idle.glb', glb: clipOnlyGLB('Idle') }])
 
-      // An unused `state` is an error under the consumer's noUnusedLocals.
-      expect(code).toContain(`const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/dummy.glb')`)
+      // `state` is still destructured — the ready gate reads it to tell a failed load from a
+      // finished one — but a model with no clips of its own contributes none to the array.
       expect(code).toContain('    ...(idle.value?.animations ?? []),')
       expect(code).not.toContain('state.value?.animations')
     })
@@ -534,6 +535,23 @@ describe('emitSFC', () => {
       expect(code).toContain('const { state: nodes0, isLoading: nodes0Loading }')
     })
 
+    /**
+     * `emit`, `isReady` and the vue imports are declared by the ready wiring, so a clip file
+     * named after one of them would redeclare it. `const { state: emit } = …` beside
+     * `const emit = defineEmits<…>()` does not compile.
+     */
+    it.each(['emit', 'isReady', 'watch', 'ref', 'computed', 'useGLTF'])(
+      'never shadows %s, which the ready wiring declares',
+      async (owned) => {
+        const { code } = await emitWithClips(skinnedNoClipsGLB(), [
+          { path: `clips/${owned}.glb`, glb: clipOnlyGLB('Idle') },
+        ])
+
+        expect(code).not.toContain(`const { state: ${owned},`)
+        expect(code).toContain(`const { state: ${owned}0, isLoading: ${owned}0Loading }`)
+      },
+    )
+
     it('leaves out a file whose clips reach nothing in this model', async () => {
       const { code } = await emitWithClips(skinnedGLB(), [
         { path: 'clips/Wrong.glb', glb: clipOnlyGLB('Wrong', ['mixamorigHips']) },
@@ -552,7 +570,6 @@ describe('emitSFC', () => {
       expect(code).toContain('const emit = defineEmits<{')
       expect(code).toContain('ready: [{ nodes: ModelNodes, materials: ModelMaterials }]')
       expect(code).toContain('const isReady = ref(false)')
-      expect(code).toContain('watch(\n  isLoading,')
       expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value })`)
       expect(code).toContain('defineExpose({ nodes, materials, isReady })')
     })
@@ -561,13 +578,28 @@ describe('emitSFC', () => {
       const { code } = await emit(simpleGLB())
 
       expect(code).toContain([
-        '  (loading) => {',
-        '    if (loading) {',
+        '  (ready) => {',
+        '    if (!ready) {',
         '      isReady.value = false',
         '      return',
         '    }',
         '    if (isReady.value) { return }',
         '    isReady.value = true',
+      ].join('\n'))
+    })
+
+    /**
+     * `isLoading` is cleared in a `finally`, so a 404 clears it exactly like a success. Only
+     * `state` tells the two apart: it is set on success and nulled on every refetch, so a
+     * failed load must never reach a `ready` handler with empty nodes and materials.
+     */
+    it('never calls a static model ready when the load failed', async () => {
+      const { code } = await emit(simpleGLB())
+
+      expect(code).toContain('const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>')
+      expect(code).toContain([
+        '  () => !isLoading.value',
+        '    && state.value !== null,',
       ].join('\n'))
     })
 
@@ -579,17 +611,50 @@ describe('emitSFC', () => {
 
       expect(code).toContain('const { state: rigMediumGeneral, isLoading: rigMediumGeneralLoading } =')
       expect(code).toContain('const { state: rigMediumMovementBasic, isLoading: rigMediumMovementBasicLoading } =')
-      expect(code).toContain('() => [isLoading.value, rigMediumGeneralLoading.value, rigMediumMovementBasicLoading.value, Object.keys(actions).length]')
-      expect(code).toContain('if (signals.slice(0, -1).some(Boolean) || !signals.at(-1)) {')
+      expect(code).toContain([
+        '  () => !isLoading.value',
+        '    && !rigMediumGeneralLoading.value',
+        '    && !rigMediumMovementBasicLoading.value',
+        '    && state.value !== null',
+        '    && Object.keys(actions).length > 0,',
+      ].join('\n'))
       expect(code).toContain('ready: [{ nodes: ModelNodes, materials: ModelMaterials, actions: Record<ActionName, AnimationAction | undefined> }]')
       expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value, actions })`)
       expect(code).toContain('defineExpose({ nodes, materials, actions, isReady })')
     })
 
+    /**
+     * The actions bind against the root group, which stays mounted whatever the load did, so
+     * clips from a `--animations` file populate `actions` even when the model itself 404s.
+     * Without the `state` term the handler would fire on a model that never arrived.
+     */
+    it('never calls an animated model ready when only its clip files loaded', async () => {
+      const { code } = await emitWithClips(skinnedNoClipsGLB(), [
+        { path: 'clips/Idle.glb', glb: clipOnlyGLB('Idle') },
+      ])
+
+      expect(code).toContain('&& state.value !== null')
+      expect(code).toContain('const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>')
+    })
+
+    /**
+     * `vue/define-macros-order` wants `defineEmits` above `defineSlots`, and a generated file
+     * the consumer's linter rewrites is a generated file that fights them on every run.
+     */
+    it('declares the emits above the slots, the order the linter wants', async () => {
+      const { code } = await emit(nestedGLB(), { slots: 'all' })
+
+      expect(code.indexOf('defineEmits<{')).toBeLessThan(code.indexOf('defineSlots<{'))
+    })
+
     it('reads only the model load when the animated model carries its own clips', async () => {
       const { code } = await emit(skinnedGLB())
 
-      expect(code).toContain('() => [isLoading.value, Object.keys(actions).length]')
+      expect(code).toContain([
+        '  () => !isLoading.value',
+        '    && state.value !== null',
+        '    && Object.keys(actions).length > 0,',
+      ].join('\n'))
       expect(code).toContain(`import type { AnimationAction, AnimationClip,`)
     })
   })

--- a/packages/cli/src/emit/sfc.test.ts
+++ b/packages/cli/src/emit/sfc.test.ts
@@ -61,7 +61,7 @@ describe('emitSFC', () => {
   it('exposes nodes and materials to the parent', async () => {
     const { code } = await emit(simpleGLB())
 
-    expect(code).toContain('defineExpose({ nodes, materials })')
+    expect(code).toContain('defineExpose({ nodes, materials, isReady })')
   })
 
   it('binds geometry and material on a mesh', async () => {
@@ -227,7 +227,7 @@ describe('emitSFC', () => {
 
     expect(code).toContain(`import { useAnimations, useGLTF } from '@tresjs/cientos'`)
     expect(code).toContain('const { actions } = useAnimations<AnimationClip, ActionName>(animations, modelRef)')
-    expect(code).toContain('defineExpose({ nodes, materials, actions })')
+    expect(code).toContain('defineExpose({ nodes, materials, actions, isReady })')
   })
 
   // A mixer resolves a track against a node name in the rendered tree, so the nodes a clip
@@ -273,7 +273,7 @@ describe('emitSFC', () => {
   it('imports the three classes it names, as types', async () => {
     const { code } = await emit(skinnedGLB())
 
-    expect(code).toContain(`import type { AnimationClip, Bone, Group, MeshStandardMaterial, Object3D, SkinnedMesh } from 'three'`)
+    expect(code).toContain(`import type { AnimationAction, AnimationClip, Bone, Group, MeshStandardMaterial, Object3D, SkinnedMesh } from 'three'`)
   })
 
   it('hands the declared shapes to useGLTF', async () => {
@@ -365,6 +365,7 @@ describe('emitSFC', () => {
       */
       import type { Group, Mesh, MeshStandardMaterial, Object3D } from 'three'
       import { useGLTF } from '@tresjs/cientos'
+      import { ref, watch } from 'vue'
 
       interface ModelNodes {
         'AuxScene': Group
@@ -384,7 +385,26 @@ describe('emitSFC', () => {
 
       const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>('/models/robot.glb')
 
-      defineExpose({ nodes, materials })
+      const emit = defineEmits<{
+        ready: [{ nodes: ModelNodes, materials: ModelMaterials }]
+      }>()
+
+      const isReady = ref(false)
+      watch(
+        isLoading,
+        (loading) => {
+          if (loading) {
+            isReady.value = false
+            return
+          }
+          if (isReady.value) { return }
+          isReady.value = true
+          emit('ready', { nodes: nodes.value, materials: materials.value })
+        },
+        { flush: 'post', immediate: true },
+      )
+
+      defineExpose({ nodes, materials, isReady })
       </script>
 
       <template>
@@ -418,8 +438,8 @@ describe('emitSFC', () => {
         { path: 'clips/Running_A.glb', glb: clipOnlyGLB('Running_A') },
       ])
 
-      expect(code).toContain(`const { state: idle } = useGLTF('/clips/Idle.glb')`)
-      expect(code).toContain(`const { state: runningA } = useGLTF('/clips/Running_A.glb')`)
+      expect(code).toContain(`const { state: idle, isLoading: idleLoading } = useGLTF('/clips/Idle.glb')`)
+      expect(code).toContain(`const { state: runningA, isLoading: runningALoading } = useGLTF('/clips/Running_A.glb')`)
     })
 
     // Real clip libraries are named `Rig_Medium_MovementBasic`; lowercasing past the first
@@ -429,7 +449,7 @@ describe('emitSFC', () => {
         { path: 'clips/Rig_Medium_MovementBasic.glb', glb: clipOnlyGLB('Walking_A') },
       ])
 
-      expect(code).toContain('const { state: rigMediumMovementBasic } =')
+      expect(code).toContain('const { state: rigMediumMovementBasic, isLoading: rigMediumMovementBasicLoading } =')
     })
 
     it('merges the clips in one array, model first', async () => {
@@ -493,7 +513,7 @@ describe('emitSFC', () => {
 
       const { code } = emitSFC(ir, { url: '/models/dummy.glb', animationURLs: ['/clips/Idle.glb'] })
 
-      expect(code).toContain(`const { state: idle } = useGLTF('/clips/Idle.glb', { draco: true })`)
+      expect(code).toContain(`const { state: idle, isLoading: idleLoading } = useGLTF('/clips/Idle.glb', { draco: true })`)
       expect(code).toContain(`useGLTF<ModelNodes, ModelMaterials>('/models/dummy.glb')`)
     })
 
@@ -502,7 +522,7 @@ describe('emitSFC', () => {
         { path: 'clips/1H_Melee_Chop.glb', glb: clipOnlyGLB('1H_Melee_Chop') },
       ])
 
-      expect(code).toContain(`const { state: clips0 } = useGLTF('/clips/1H_Melee_Chop.glb')`)
+      expect(code).toContain(`const { state: clips0, isLoading: clips0Loading } = useGLTF('/clips/1H_Melee_Chop.glb')`)
     })
 
     it('never shadows an identifier the generated file already owns', async () => {
@@ -510,8 +530,8 @@ describe('emitSFC', () => {
         { path: 'clips/nodes.glb', glb: clipOnlyGLB('Idle') },
       ])
 
-      expect(code).not.toContain('const { state: nodes }')
-      expect(code).toContain('const { state: nodes0 }')
+      expect(code).not.toContain('const { state: nodes,')
+      expect(code).toContain('const { state: nodes0, isLoading: nodes0Loading }')
     })
 
     it('leaves out a file whose clips reach nothing in this model', async () => {
@@ -522,6 +542,55 @@ describe('emitSFC', () => {
       // Loading a file to merge nothing out of it is a request for nothing.
       expect(code).not.toContain('/clips/Wrong.glb')
       expect(code).toContain('const animations = computed(() => state.value?.animations ?? [])')
+    })
+  })
+
+  describe('@ready / isReady', () => {
+    it('emits ready and exposes isReady on a static model', async () => {
+      const { code } = await emit(simpleGLB())
+
+      expect(code).toContain('const emit = defineEmits<{')
+      expect(code).toContain('ready: [{ nodes: ModelNodes, materials: ModelMaterials }]')
+      expect(code).toContain('const isReady = ref(false)')
+      expect(code).toContain('watch(\n  isLoading,')
+      expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value })`)
+      expect(code).toContain('defineExpose({ nodes, materials, isReady })')
+    })
+
+    it('gates static ready on the load and resets it on a refetch', async () => {
+      const { code } = await emit(simpleGLB())
+
+      expect(code).toContain([
+        '  (loading) => {',
+        '    if (loading) {',
+        '      isReady.value = false',
+        '      return',
+        '    }',
+        '    if (isReady.value) { return }',
+        '    isReady.value = true',
+      ].join('\n'))
+    })
+
+    it('waits for every clip source and bound actions before an animated model is ready', async () => {
+      const { code } = await emitWithClips(skinnedNoClipsGLB(), [
+        { path: 'clips/Rig_Medium_General.glb', glb: clipOnlyGLB('Idle_A') },
+        { path: 'clips/Rig_Medium_MovementBasic.glb', glb: clipOnlyGLB('Jump_Start') },
+      ])
+
+      expect(code).toContain('const { state: rigMediumGeneral, isLoading: rigMediumGeneralLoading } =')
+      expect(code).toContain('const { state: rigMediumMovementBasic, isLoading: rigMediumMovementBasicLoading } =')
+      expect(code).toContain('() => [isLoading.value, rigMediumGeneralLoading.value, rigMediumMovementBasicLoading.value, Object.keys(actions).length]')
+      expect(code).toContain('if (signals.slice(0, -1).some(Boolean) || !signals.at(-1)) {')
+      expect(code).toContain('ready: [{ nodes: ModelNodes, materials: ModelMaterials, actions: Record<ActionName, AnimationAction | undefined> }]')
+      expect(code).toContain(`emit('ready', { nodes: nodes.value, materials: materials.value, actions })`)
+      expect(code).toContain('defineExpose({ nodes, materials, actions, isReady })')
+    })
+
+    it('reads only the model load when the animated model carries its own clips', async () => {
+      const { code } = await emit(skinnedGLB())
+
+      expect(code).toContain('() => [isLoading.value, Object.keys(actions).length]')
+      expect(code).toContain(`import type { AnimationAction, AnimationClip,`)
     })
   })
 })

--- a/packages/cli/src/emit/sfc.ts
+++ b/packages/cli/src/emit/sfc.ts
@@ -97,6 +97,48 @@ function isContainer(node: IRNode): boolean {
   return !node.geometry && !isPassthrough(node)
 }
 
+/** The `ready` payload and `emit` call, by whether the model carries clips. */
+const READY_PAYLOAD = {
+  animated: {
+    type: '{ nodes: ModelNodes, materials: ModelMaterials, actions: Record<ActionName, AnimationAction | undefined> }',
+    value: '{ nodes: nodes.value, materials: materials.value, actions }',
+  },
+  static: {
+    type: '{ nodes: ModelNodes, materials: ModelMaterials }',
+    value: '{ nodes: nodes.value, materials: materials.value }',
+  },
+} as const
+
+/**
+ * The `ready`/`isReady` pair. Emits are one-shot, so a parent that binds late has nothing to
+ * read — `isReady` is the replayable half. Post-flush so it fires after the tree is in the
+ * graph, and resets to `false` on any reload (`useGLTF` exposes `execute()`) so it never lies
+ * after a refetch. `source` is what the watch reads, `notReady` the guard that keeps it from
+ * firing before every load has landed and the actions are bound.
+ */
+function readySetup(payload: { type: string, value: string }, source: string, param: string, notReady: string): string[] {
+  return [
+    'const emit = defineEmits<{',
+    `${INDENT}ready: [${payload.type}]`,
+    '}>()',
+    '',
+    'const isReady = ref(false)',
+    'watch(',
+    `${INDENT}${source},`,
+    `${INDENT}(${param}) => {`,
+    `${INDENT.repeat(2)}if (${notReady}) {`,
+    `${INDENT.repeat(3)}isReady.value = false`,
+    `${INDENT.repeat(3)}return`,
+    `${INDENT.repeat(2)}}`,
+    `${INDENT.repeat(2)}if (isReady.value) { return }`,
+    `${INDENT.repeat(2)}isReady.value = true`,
+    `${INDENT.repeat(2)}emit('ready', ${payload.value})`,
+    `${INDENT}},`,
+    `${INDENT}{ flush: 'post', immediate: true },`,
+    ')',
+  ]
+}
+
 export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
   const {
     url,
@@ -455,9 +497,14 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
   const threeTypes = instanced
     ? new Set([
         ...slotSpecs.flatMap(slot => slot.bindings.map(binding => binding.type)),
-        ...(hasAnimations ? ['AnimationClip'] : []),
+        ...(hasAnimations ? ['AnimationClip', 'AnimationAction'] : []),
       ].filter(type => THREE_CLASS.test(type)))
     : modelThreeTypes
+
+  // The `ready` payload types `actions` as `AnimationAction`, which `modelTypes` leaves out.
+  if (hasAnimations && !instanced) {
+    threeTypes.add('AnimationAction')
+  }
 
   const cientos = [
     instanced ? 'Instance' : '',
@@ -469,12 +516,15 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
     // Instancing hands the clips over already wrapped, so only the standalone build computes them.
     ...(hasAnimations && !instanced ? ['computed'] : []),
     ...(instanced ? ['inject'] : []),
-    ...(hasAnimations ? ['ref'] : []),
+    // `ready`/`isReady` need both on every variant.
+    'ref',
+    'watch',
   ]
 
   // The provider declares the model's shapes, so this file imports them instead of
   // repeating them. Types only: the injection key itself is a literal in both files.
-  const provided = [...(hasAnimations ? ['ActionName'] : []), 'ModelContext']
+  // `ModelNodes` / `ModelMaterials` are named in the `ready` payload type.
+  const provided = [...(hasAnimations ? ['ActionName'] : []), 'ModelNodes', 'ModelMaterials', 'ModelContext']
 
   const imports = [
     threeTypes.size > 0 ? `import type { ${[...threeTypes].sort().join(', ')} } from 'three'` : '',
@@ -484,11 +534,10 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
     vue.length > 0 ? `import { ${vue.join(', ')} } from 'vue'` : '',
   ].filter(Boolean)
 
-  const animationSetup = [
+  const animationBind = [
     `const modelRef = ref()`,
     `const { actions } = useAnimations<AnimationClip, ActionName>(animations, modelRef)`,
     '',
-    `defineExpose({ nodes, materials, actions })`,
   ]
 
   const setup = instanced
@@ -500,20 +549,45 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
         '',
         `const { ${['nodes', 'materials', ...(hasAnimations ? ['animations'] : [])].join(', ')} } = context`,
         '',
-        ...(hasAnimations ? animationSetup : [`defineExpose({ nodes, materials })`]),
+        // No `isLoading` here — the provider owns the load — so ready follows the injected data:
+        // the actions binding when animated, the nodes populating when not.
+        ...(hasAnimations
+          ? [
+              ...animationBind,
+              ...readySetup(READY_PAYLOAD.animated, '() => Object.keys(actions).length', 'count', '!count'),
+              '',
+              `defineExpose({ nodes, materials, actions, isReady })`,
+            ]
+          : [
+              ...readySetup(READY_PAYLOAD.static, '() => Object.keys(nodes.value).length', 'count', '!count'),
+              '',
+              `defineExpose({ nodes, materials, isReady })`,
+            ]),
       ]
     : hasAnimations
       ? [
           `const { ${[...(hasOwnClips ? ['state'] : []), 'nodes', 'materials', 'isLoading'].join(', ')} } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
-          ...clipLoads(sources),
+          ...clipLoads(sources, { loading: true }),
           '',
           ...mergedClips(hasOwnClips, sources),
-          ...animationSetup,
+          ...animationBind,
+          // Ready means every source loaded AND the actions bound: each clip file resolves on its
+          // own, so a handler firing on the first population would see the later clips undefined.
+          ...readySetup(
+            READY_PAYLOAD.animated,
+            `() => [${['isLoading.value', ...sources.map(source => `${source.loading}.value`)].join(', ')}, Object.keys(actions).length]`,
+            'signals',
+            'signals.slice(0, -1).some(Boolean) || !signals.at(-1)',
+          ),
+          '',
+          `defineExpose({ nodes, materials, actions, isReady })`,
         ]
       : [
           `const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
           '',
-          `defineExpose({ nodes, materials })`,
+          ...readySetup(READY_PAYLOAD.static, 'isLoading', 'loading', 'loading'),
+          '',
+          `defineExpose({ nodes, materials, isReady })`,
         ]
 
   /**

--- a/packages/cli/src/emit/sfc.ts
+++ b/packages/cli/src/emit/sfc.ts
@@ -110,23 +110,44 @@ const READY_PAYLOAD = {
 } as const
 
 /**
- * The `ready`/`isReady` pair. Emits are one-shot, so a parent that binds late has nothing to
- * read — `isReady` is the replayable half. Post-flush so it fires after the tree is in the
- * graph, and resets to `false` on any reload (`useGLTF` exposes `execute()`) so it never lies
- * after a refetch. `source` is what the watch reads, `notReady` the guard that keeps it from
- * firing before every load has landed and the actions are bound.
+ * The `ready` declaration. Separate from the wiring below because it has to sit above
+ * `defineSlots`, which `vue/define-macros-order` enforces in the consumer's own lint run.
  */
-function readySetup(payload: { type: string, value: string }, source: string, param: string, notReady: string): string[] {
+function readyEmits(payload: { type: string, value: string }): string[] {
   return [
     'const emit = defineEmits<{',
     `${INDENT}ready: [${payload.type}]`,
     '}>()',
     '',
+  ]
+}
+
+/**
+ * The `ready`/`isReady` pair. The event is one-shot per load, so a parent that binds late has
+ * nothing to read — `isReady` is the replayable half. Post-flush so it fires after the tree is
+ * in the graph, and back to `false` the moment any term stops holding, so it never lies after a
+ * refetch (`useGLTF` exposes `execute()`).
+ *
+ * `terms` are AND-ed into one boolean, which is what the watch reads: the callback then only
+ * runs when readiness actually flips, and each term names what it waits for instead of sitting
+ * at a position in an array the guard has to index.
+ */
+function readySetup(payload: { type: string, value: string }, terms: string[]): string[] {
+  // `&&` leads its line: `style/operator-linebreak`, the shape the consumer's linter wants.
+  const source = terms.length === 1
+    ? [`${INDENT}() => ${terms[0]},`]
+    : [
+        `${INDENT}() => ${terms[0]}`,
+        ...terms.slice(1).map((term, index) =>
+          `${INDENT.repeat(2)}&& ${term}${index === terms.length - 2 ? ',' : ''}`),
+      ]
+
+  return [
     'const isReady = ref(false)',
     'watch(',
-    `${INDENT}${source},`,
-    `${INDENT}(${param}) => {`,
-    `${INDENT.repeat(2)}if (${notReady}) {`,
+    ...source,
+    `${INDENT}(ready) => {`,
+    `${INDENT.repeat(2)}if (!ready) {`,
     `${INDENT.repeat(3)}isReady.value = false`,
     `${INDENT.repeat(3)}return`,
     `${INDENT.repeat(2)}}`,
@@ -523,8 +544,14 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
 
   // The provider declares the model's shapes, so this file imports them instead of
   // repeating them. Types only: the injection key itself is a literal in both files.
-  // `ModelNodes` / `ModelMaterials` are named in the `ready` payload type.
-  const provided = [...(hasAnimations ? ['ActionName'] : []), 'ModelNodes', 'ModelMaterials', 'ModelContext']
+  // `ModelNodes` / `ModelMaterials` are named in the `ready` payload type. Sorted, because
+  // `perfectionist/sort-named-imports` reads the generated file as readily as a written one.
+  const provided = [
+    ...(hasAnimations ? ['ActionName'] : []),
+    'ModelContext',
+    'ModelMaterials',
+    'ModelNodes',
+  ]
 
   const imports = [
     threeTypes.size > 0 ? `import type { ${[...threeTypes].sort().join(', ')} } from 'three'` : '',
@@ -549,43 +576,49 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
         '',
         `const { ${['nodes', 'materials', ...(hasAnimations ? ['animations'] : [])].join(', ')} } = context`,
         '',
-        // No `isLoading` here — the provider owns the load — so ready follows the injected data:
-        // the actions binding when animated, the nodes populating when not.
+        // No `isLoading` or `state` here — the provider owns the load — so ready follows the
+        // injected data: the actions binding when animated, the nodes populating when not.
         ...(hasAnimations
           ? [
               ...animationBind,
-              ...readySetup(READY_PAYLOAD.animated, '() => Object.keys(actions).length', 'count', '!count'),
+              ...readySetup(READY_PAYLOAD.animated, ['Object.keys(actions).length > 0']),
               '',
               `defineExpose({ nodes, materials, actions, isReady })`,
             ]
           : [
-              ...readySetup(READY_PAYLOAD.static, '() => Object.keys(nodes.value).length', 'count', '!count'),
+              ...readySetup(READY_PAYLOAD.static, ['Object.keys(nodes.value).length > 0']),
               '',
               `defineExpose({ nodes, materials, isReady })`,
             ]),
       ]
     : hasAnimations
       ? [
-          `const { ${[...(hasOwnClips ? ['state'] : []), 'nodes', 'materials', 'isLoading'].join(', ')} } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
+          `const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
           ...clipLoads(sources, { loading: true }),
           '',
           ...mergedClips(hasOwnClips, sources),
           ...animationBind,
-          // Ready means every source loaded AND the actions bound: each clip file resolves on its
-          // own, so a handler firing on the first population would see the later clips undefined.
-          ...readySetup(
-            READY_PAYLOAD.animated,
-            `() => [${['isLoading.value', ...sources.map(source => `${source.loading}.value`)].join(', ')}, Object.keys(actions).length]`,
-            'signals',
-            'signals.slice(0, -1).some(Boolean) || !signals.at(-1)',
-          ),
+          // Every source has to land AND the actions bind: each clip file resolves on its own, so
+          // a handler firing on the first population would see the later clips undefined. `state`
+          // is the one that tells a finished load from a failed one — the actions bind against the
+          // root group, which stays mounted whatever the model did, so clips from a `--animations`
+          // file fill `actions` even when the model itself never arrived.
+          ...readySetup(READY_PAYLOAD.animated, [
+            '!isLoading.value',
+            ...sources.map(source => `!${source.loading}.value`),
+            'state.value !== null',
+            'Object.keys(actions).length > 0',
+          ]),
           '',
           `defineExpose({ nodes, materials, actions, isReady })`,
         ]
       : [
-          `const { nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
+          `const { state, nodes, materials, isLoading } = useGLTF<ModelNodes, ModelMaterials>(${loaderArgs})`,
           '',
-          ...readySetup(READY_PAYLOAD.static, 'isLoading', 'loading', 'loading'),
+          // `isLoading` is cleared in a `finally`, so a 404 clears it exactly like a success.
+          // `state` is set only when the load produced a scene, and nulled again on every
+          // refetch, so it is what keeps a failed load out of a `ready` handler.
+          ...readySetup(READY_PAYLOAD.static, ['!isLoading.value', 'state.value !== null']),
           '',
           `defineExpose({ nodes, materials, isReady })`,
         ]
@@ -651,6 +684,9 @@ export function emitSFC(ir: GLTFIR, options: EmitOptions): EmitResult {
     ...imports,
     '',
     ...(instanced ? [] : localTypes),
+    // Above `defineSlots`: `vue/define-macros-order` wants the macros in that order, and the
+    // payload type is declared (or imported) further up either way.
+    ...readyEmits(hasAnimations ? READY_PAYLOAD.animated : READY_PAYLOAD.static),
     ...slotTypes,
     ...setup,
     '</script>',

--- a/packages/cli/src/emit/shared.ts
+++ b/packages/cli/src/emit/shared.ts
@@ -78,6 +78,8 @@ const RESERVED = new Set([
 export interface ClipSource {
   /** What the `state` of its `useGLTF` is renamed to. */
   variable: string
+  /** What its `isLoading` is renamed to, when the ready watch reads it. */
+  loading: string
   url: string
   draco: boolean
 }
@@ -118,14 +120,25 @@ export function clipSources(sources: IRAnimationSource[], urls: string[] = []): 
     .map(({ source, url }, index) => {
       const variable = toVariable(source.path, index, taken)
       taken.add(variable)
-      return { variable, url, draco: source.draco }
+      let loading = `${variable}Loading`
+      while (taken.has(loading)) {
+        loading = `${loading}${index}`
+      }
+      taken.add(loading)
+      return { variable, loading, url, draco: source.draco }
     })
 }
 
-/** One `useGLTF` per clip file. Only its clips are read, so nothing else is destructured. */
-export function clipLoads(sources: ClipSource[]): string[] {
-  return sources.map(({ variable, url, draco }) =>
-    `const { state: ${variable} } = useGLTF(${draco ? `'${url}', { draco: true }` : `'${url}'`})`)
+/**
+ * One `useGLTF` per clip file. Only the clips are read, so `state` is all that is
+ * destructured — unless `loading` is asked for, which the ready watch needs to know
+ * every source has landed.
+ */
+export function clipLoads(sources: ClipSource[], options: { loading?: boolean } = {}): string[] {
+  return sources.map(({ variable, loading, url, draco }) => {
+    const bindings = options.loading ? `state: ${variable}, isLoading: ${loading}` : `state: ${variable}`
+    return `const { ${bindings} } = useGLTF(${draco ? `'${url}', { draco: true }` : `'${url}'`})`
+  })
 }
 
 /**

--- a/packages/cli/src/emit/shared.ts
+++ b/packages/cli/src/emit/shared.ts
@@ -57,10 +57,15 @@ export function header(command: string | undefined, ...notes: string[]): string[
 }
 
 /**
- * Identifiers the generated files already own. A clip file called `nodes.glb` must not
- * shadow one of them.
+ * Identifiers the generated files already own, as locals or as imports. A clip file called
+ * `nodes.glb` must not shadow one of them, and neither must `emit.glb` shadow the `emit` the
+ * ready wiring declares — a redeclaration does not compile.
+ *
+ * Only names a clip variable could actually take are worth listing: `toVariable` lowercases
+ * the first letter, so `Instance`, `Merged` and the three classes are out of reach.
  */
 const RESERVED = new Set([
+  // Locals the setup block declares.
   'state',
   'nodes',
   'materials',
@@ -72,6 +77,15 @@ const RESERVED = new Set([
   'meshes',
   'limit',
   'props',
+  'emit',
+  'isReady',
+  // Imported bindings, which a `const` in the same file redeclares just as loudly.
+  'computed',
+  'inject',
+  'ref',
+  'watch',
+  'useAnimations',
+  'useGLTF',
 ])
 
 /** A `--animations` file as the emitted file sees it: one `useGLTF` call and one spread. */


### PR DESCRIPTION
## Summary

Generated SFCs gave consumers no readiness signal, so every consumer reinvented the same fragile watch on `actions` going from empty to filled. That needs a template ref (a footgun under the Tres renderer, `useTemplateRef` is not populated) and it fires early on multi-source models.

- Generated SFCs now emit a `@ready` event and expose a pollable `isReady`, on all four variants (standalone/instanced x animated/static).
- **Ready** means the load actually produced a model and, when animated, `useAnimations` has bound its actions (post-flush, after the rig is in the graph). The terms are AND-ed into one named boolean, so each condition says what it waits for.
- `isReady` goes back to `false` the moment any term stops holding, so it never lies after a `useGLTF` `execute()` refetch, and `ready` fires again once ready holds. The event is one-shot **per load**.
- Standalone animated models destructure each `--animations` source's `isLoading` and gate on all of them. This fixes the early-fire on multi-source rigs where `actions` populates with only the first library's clips, leaving e.g. `actions.Jump_Start === undefined` for a handler that fired on the first population.
- Instanced models have no `isLoading` of their own (the provider owns the load), so ready follows the injected data: the actions binding when animated, `nodes` populating when not.

Consumers become:

```vue
<Dummy @ready="({ actions }) => actions.Idle_A?.reset().fadeIn(0.2).play()" />
```

Emits alone are not enough (not replayable), hence shipping both: `isReady` covers a parent that binds late or a state machine that asks later.

### A finished load is not a successful one

`isLoading` comes from VueUse `useAsyncState` via `useLoader`, and it is cleared in a `finally` — a 404 clears it exactly like a success, and `throwError` defaults to false so nothing surfaces. Readiness therefore also requires `state !== null`, which is set only when the load produced a scene and nulled again on every refetch.

Two variants needed that term, not one:

| Variant | On model load failure |
| :--- | :--- |
| standalone static | `isLoading` clears, nothing else to catch it |
| standalone animated, external clips | actions bind against the **root group**, which stays mounted whatever the load did, so clips from an `--animations` file fill `actions` even though the model never arrived |
| standalone animated, own clips only | already safe: `animations` is `state?.animations ?? []` |
| instanced (both) | already safe: the provider's `nodes` / `animations` stay empty |

`useGLTF`'s declared return type omits `isReady`, so reading VueUse's own flag would have needed a cientos API change; `state` is the signal already on the public surface.

### Generated output has to satisfy the consumer's linter

A generated file the consumer's linter wants to rewrite fights them on every run, so the output is linted against this repo's config: `defineEmits` sits above `defineSlots` (`vue/define-macros-order`), the provider type import is sorted (`perfectionist/sort-named-imports`), and the `&&` chain leads its lines (`style/operator-linebreak`).

`RESERVED` now also covers the identifiers the ready wiring owns — `emit`, `isReady`, `watch`, `ref`, `computed`, `inject`, `useGLTF`, `useAnimations` — so a clip file named `emit.glb` can no longer generate `const { state: emit } = …` beside `const emit = defineEmits<…>()`.

### Docs

`tres gltf` page and the cli README updated: generated examples match the new output, the animated example drops the template-ref pattern for `@ready`, and the multi-source section explains why readiness waits for every clip file and why `state` is in the gate.

## Test plan

- [x] `pnpm --filter @tresjs/cli test` - 280 pass, including `compiles.test` which runs the real Vue compiler over the output for all four variants
- [x] Failure-path coverage: tests assert the `state` term is in the gate for both standalone variants
- [x] Collision coverage: a clip file named after each owned identifier is renamed rather than shadowing it
- [x] `tsc --noEmit` clean, `eslint` clean on all changed files
- [x] Ran eslint over the **generated** output for all four variants: no new errors (6 pre-existing `vue/no-useless-v-bind` on the batched-slot `:batch="'Rock_0'"` bindings, untouched by this PR)

Closes TRES-387