### PR TITLE
fix(core): apply customRendererOptions default in TresCanvas

### DIFF
--- a/packages/core/src/components/TresCanvas.vue
+++ b/packages/core/src/components/TresCanvas.vue
@@ -31,9 +31,9 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
   enableProvideBridge: true, // We should probably move to options in next major version
   toneMapping: ACESFilmicToneMapping,
   shadowMapType: PCFSoftShadowMap,
-  options: {
+  customRendererOptions: () => ({
     primitivePrefix: '',
-  },
+  }),
 })
 
 const emit = defineEmits<TresCanvasEmits>()


### PR DESCRIPTION
The `options` key in withDefaults did not match any declared prop on TresCanvasProps, so the `primitivePrefix` default never reached Context.vue and `:options` was silently ignored at runtime.

Rename the default to the actual `customRendererOptions` prop and use Vue's function-form default, which is required for object types by withDefaults and prevents a shared mutable reference. This aligns the component with the documented `:custom-renderer-options` API.