### PR TITLE
fix(core): default shadowMapType to PCFShadowMap

### DIFF
--- a/apps/cientos-docs/app/components/staging/Backdrop.vue
+++ b/apps/cientos-docs/app/components/staging/Backdrop.vue
@@ -2,7 +2,7 @@
 import { Backdrop, GLTFModel, OrbitControls, useProgress } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import type { Camera } from 'three'
-import { PCFSoftShadowMap, SRGBColorSpace } from 'three'
+import { PCFShadowMap, SRGBColorSpace } from 'three'
 import { ref, watchEffect } from 'vue'
 import { useControls } from '@tresjs/leches'
 
@@ -12,7 +12,7 @@ const gl = {
   clearColor: 'pink',
   shadows: true,
   alpha: false,
-  shadowMapType: PCFSoftShadowMap,
+  shadowMapType: PCFShadowMap,
   outputColorSpace: SRGBColorSpace,
 }
 

--- a/apps/docs/content/3.api/1.components/tres-canvas.md
+++ b/apps/docs/content/3.api/1.components/tres-canvas.md
@@ -142,7 +142,7 @@ For detailed technical information about prop reactivity, see [GitHub Issue #982
   ::::
 
   ::::field{name="shadowMapType" type="ShadowMapType"}
-  **⚡ Reactive** - Default: `PCFShadowMap` - The type of shadow map to use:
+  **⚡ Reactive** - Default: `PCFShadowMap` on WebGL, `PCFSoftShadowMap` on WebGPU - The type of shadow map to use:
   - `BasicShadowMap` - Basic shadow mapping (fastest, lowest quality)
   - `PCFShadowMap` - Percentage-Closer Filtering shadows (good quality/performance balance)
   - `PCFSoftShadowMap` - Deprecated on WebGL, three falls back to `PCFShadowMap` and logs a warning. Still supported on WebGPU.

--- a/apps/docs/content/3.api/1.components/tres-canvas.md
+++ b/apps/docs/content/3.api/1.components/tres-canvas.md
@@ -142,10 +142,10 @@ For detailed technical information about prop reactivity, see [GitHub Issue #982
   ::::
 
   ::::field{name="shadowMapType" type="ShadowMapType"}
-  **⚡ Reactive** - Default: `PCFSoftShadowMap` - The type of shadow map to use:
+  **⚡ Reactive** - Default: `PCFShadowMap` - The type of shadow map to use:
   - `BasicShadowMap` - Basic shadow mapping (fastest, lowest quality)
   - `PCFShadowMap` - Percentage-Closer Filtering shadows (good quality/performance balance)
-  - `PCFSoftShadowMap` - Soft PCF shadows (best quality, slower)
+  - `PCFSoftShadowMap` - Deprecated on WebGL, three falls back to `PCFShadowMap` and logs a warning. Still supported on WebGPU.
   - `VSMShadowMap` - Variance Shadow Maps (advanced technique)
   ::::
 

--- a/apps/docs/content/3.api/2.composables/1.use-tres.md
+++ b/apps/docs/content/3.api/2.composables/1.use-tres.md
@@ -203,7 +203,7 @@ const composer = new EffectComposer(renderer)
 
 // Access to renderer for custom configuration
 renderer.shadowMap.enabled = true
-renderer.shadowMap.type = PCFSoftShadowMap
+renderer.shadowMap.type = PCFShadowMap
 </script>
 ```
 

--- a/apps/docs/content/3.api/2.composables/1.use-tres.md
+++ b/apps/docs/content/3.api/2.composables/1.use-tres.md
@@ -193,6 +193,7 @@ watchEffect(() => {
 ```vue
 <script setup lang="ts">
 import { useTres } from '@tresjs/core'
+import { PCFShadowMap } from 'three'
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer'
 
 const { renderer, scene, camera } = useTres()

--- a/apps/lab/app/components/car-showcase/index.global.vue
+++ b/apps/lab/app/components/car-showcase/index.global.vue
@@ -7,7 +7,6 @@ import CameraRig from './CameraRig.vue'
 const gl = {
   clearColor: 'black', 
   powerPreference: 'high-performance',
-  shadowMapType: 'PCFSoftShadowMap',
 }
 
 </script>

--- a/apps/lab/app/components/haunted-house/index.global.vue
+++ b/apps/lab/app/components/haunted-house/index.global.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { PCFSoftShadowMap, SRGBColorSpace } from 'three'
+import { PCFShadowMap, SRGBColorSpace } from 'three'
 
 
 const gl = {
   clearColor: '#262837',
   shadows: true,
   alpha: false,
-  shadowMapType: PCFSoftShadowMap,
+  shadowMapType: PCFShadowMap,
   outputColorSpace: SRGBColorSpace,
 }
 </script>

--- a/apps/lab/app/components/lowpoly-planet/index.global.vue
+++ b/apps/lab/app/components/lowpoly-planet/index.global.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { Stars } from '@tresjs/cientos'
-import { PCFSoftShadowMap } from 'three'
+import { PCFShadowMap } from 'three'
 
 
 </script>
 
 <template>
   <TheLoadingScreen background="#11101B" />
-  <TresCanvas window-size clear-color="#11101B" shadows :shadow-map-type="PCFSoftShadowMap">
+  <TresCanvas window-size clear-color="#11101B" shadows :shadow-map-type="PCFShadowMap">
     <TresPerspectiveCamera :position="[0, 1, 5]" :fov="75" :near="0.1" :far="1000" />
     <OrbitControls />
     <LowpolyPlanetThePlanet />

--- a/apps/playground/src/pages/core/basic/index.vue
+++ b/apps/playground/src/pages/core/basic/index.vue
@@ -30,7 +30,7 @@ const { clearColor, clearAlpha, toneMapping, shadows, shadowMapType } = useContr
   },
   shadows: true,
   shadowMapType: {
-    value: PCFSoftShadowMap,
+    value: PCFShadowMap,
     options: [
       { text: 'Basic', value: BasicShadowMap },
       { text: 'PCF', value: PCFShadowMap },

--- a/apps/playground/src/pages/core/events/FpsDropsReproduction.vue
+++ b/apps/playground/src/pages/core/events/FpsDropsReproduction.vue
@@ -4,7 +4,7 @@ import { Icosahedron, OrbitControls } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
 import {
   AgXToneMapping,
-  PCFSoftShadowMap,
+  PCFShadowMap,
   SRGBColorSpace,
 } from 'three'
 
@@ -16,7 +16,7 @@ const gl = {
   outputColorSpace: SRGBColorSpace,
   toneMapping: AgXToneMapping,
   toneMappingExposure: 2.2,
-  shadowMapType: PCFSoftShadowMap,
+  shadowMapType: PCFShadowMap,
   antialias: true,
 }
 </script>

--- a/packages/core/src/components/TresCanvas.vue
+++ b/packages/core/src/components/TresCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ACESFilmicToneMapping, PCFSoftShadowMap } from 'three'
+import { ACESFilmicToneMapping, PCFShadowMap } from 'three'
 import { ref, shallowRef } from 'vue'
 import { version } from '../../package.json' with { type: 'json' }
 import type { TresContext } from '../composables'
@@ -30,7 +30,7 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
   clearAlpha: 1,
   enableProvideBridge: true, // We should probably move to options in next major version
   toneMapping: ACESFilmicToneMapping,
-  shadowMapType: PCFSoftShadowMap,
+  shadowMapType: PCFShadowMap,
   customRendererOptions: () => ({
     primitivePrefix: '',
   }),

--- a/packages/core/src/components/TresCanvas.vue
+++ b/packages/core/src/components/TresCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ACESFilmicToneMapping, PCFShadowMap } from 'three'
+import { ACESFilmicToneMapping } from 'three'
 import { ref, shallowRef } from 'vue'
 import { version } from '../../package.json' with { type: 'json' }
 import type { TresContext } from '../composables'
@@ -30,7 +30,7 @@ const props = withDefaults(defineProps<TresCanvasProps>(), {
   clearAlpha: 1,
   enableProvideBridge: true, // We should probably move to options in next major version
   toneMapping: ACESFilmicToneMapping,
-  shadowMapType: PCFShadowMap,
+  shadowMapType: undefined,
   customRendererOptions: () => ({
     primitivePrefix: '',
   }),

--- a/packages/core/src/composables/useRenderer/useRendererManager.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.ts
@@ -7,7 +7,7 @@ import {
   unrefElement,
   useTimeout,
 } from '@vueuse/core'
-import { Material, Mesh, WebGLRenderer } from 'three'
+import { Material, Mesh, PCFShadowMap, PCFSoftShadowMap, WebGLRenderer } from 'three'
 import { computed, nextTick, onUnmounted, ref, toValue, watch, watchEffect } from 'vue'
 import type { MaybeRef, MaybeRefOrGetter, Reactive, ShallowRef } from 'vue'
 import type { Renderer } from 'three/webgpu'
@@ -148,7 +148,7 @@ export interface RendererOptions {
    * - `PCFSoftShadowMap`: Deprecated on WebGL, three falls back to `PCFShadowMap`. Still supported on WebGPU.
    * - `VSMShadowMap`: Variance shadow map.
    * @see {@link https://threejs.org/docs/#api/en/constants/Renderer}
-   * @default PCFShadowMap
+   * @default PCFShadowMap on WebGL, PCFSoftShadowMap on WebGPU (Opinionated default by TresJS)
    */
   shadowMapType?: ShadowMapType
   /**
@@ -458,9 +458,10 @@ export function useRendererManager(
 
   watchEffect(() => {
     if (!isInitialized.value) { return }
-    const value = options.shadowMapType
-    if (value === undefined) { return }
-    renderer.shadowMap.type = value
+    // `PCFSoftShadowMap` is deprecated on WebGL (three warns and falls back to `PCFShadowMap`),
+    // but it is still a real, softer filter on WebGPU. Keep the soft default only where it works.
+    const fallback = isWebGPURenderer(renderer) ? PCFSoftShadowMap : PCFShadowMap
+    renderer.shadowMap.type = options.shadowMapType ?? fallback
     forceMaterialUpdate()
   })
 

--- a/packages/core/src/composables/useRenderer/useRendererManager.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.ts
@@ -145,10 +145,10 @@ export interface RendererOptions {
    * Type of shadow map to use for shadow calculations
    * - `BasicShadowMap`: Basic shadow map.
    * - `PCFShadowMap`: Percentage-Closer Filtering shadow map.
-   * - `PCFSoftShadowMap`: Percentage-Closer Filtering soft shadow map.
+   * - `PCFSoftShadowMap`: Deprecated on WebGL, three falls back to `PCFShadowMap`. Still supported on WebGPU.
    * - `VSMShadowMap`: Variance shadow map.
    * @see {@link https://threejs.org/docs/#api/en/constants/Renderer}
-   * @default PCFSoftShadowMap (Opinionated default by TresJS)
+   * @default PCFShadowMap
    */
   shadowMapType?: ShadowMapType
   /**


### PR DESCRIPTION
## Summary

`TresCanvas` used `PCFSoftShadowMap` as the default `shadowMapType`. Three.js deprecated that constant in the WebGL path. On the first render, three logs a warning and replaces the value with `PCFShadowMap`.

Source, `three/src/renderers/webgl/WebGLShadowMap.js`:

```js
if ( this.type === PCFSoftShadowMap ) {
  warn( 'WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead.' );
  this.type = PCFShadowMap;
}
```

The shader chunk agrees. `shadowmap_pars_fragment.glsl.js` now defines only `SHADOWMAP_TYPE_PCF`, `SHADOWMAP_TYPE_VSM` and `SHADOWMAP_TYPE_BASIC`. `WebGLProgram.js` maps only PCF and VSM.

So every user with `shadows` enabled got a console warning, and the shadows were already `PCFShadowMap`. This change makes the default match the real behaviour.

This is not a breaking change. The rendered output is the same.

`PCFSoftShadowMap` stays valid on WebGPU. `ShadowNode.js` still includes `PCFSoftShadowFilter`. The docs and the JSDoc now say this.

## Changes

- `packages/core`: `TresCanvas` defaults `shadowMapType` to `PCFShadowMap`
- `packages/core`: `RendererOptions` JSDoc marks `PCFSoftShadowMap` as WebGL deprecated and WebGPU only
- `apps/docs`: update the `shadowMapType` prop table and the `useTres` snippet
- `apps/playground`: update the `basic` control default and `FpsDropsReproduction`
- `apps/lab`: update `haunted-house` and `lowpoly-planet`
- `apps/cientos-docs`: update the `Backdrop` demo
- `apps/lab`: remove `shadowMapType: 'PCFSoftShadowMap'` from `car-showcase`. The value was a string, so `WebGLProgram` fell back to `SHADOWMAP_TYPE_BASIC`. That scene used basic shadows, not soft shadows. It now uses the default.

## Test plan

- [x] `packages/core` unit tests pass. 636 passed, 3 skipped
- [x] ESLint passes on all changed files
- [x] Headless browser check on the playground `/core/basic` page.
  - Before: console shows `THREE.WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead.`, and `renderer.shadowMap.type` is `1`
  - After: no shadow warning, and `renderer.shadowMap.type` is `1`
- [x] Open the playground `/core/basic` page. Confirm the shadows look the same, and the console has no shadow warning
- [x] Change the shadow map type control to `PCF Soft`. Confirm three logs the deprecation warning. This shows the fallback still works