### PR TITLE
docs(staging): fix Lightformer example import and prop name

### DIFF
--- a/apps/cientos-docs/content/2.api/8.staging/3.lightformer.md
+++ b/apps/cientos-docs/content/2.api/8.staging/3.lightformer.md
@@ -1,6 +1,6 @@
 ---
 title: Lightformer
-description: Addon for environment component that provided you custom lights.
+description: Addon for the Environment component that provides custom lights.
 ---
 
 ::SceneControlsWrapper
@@ -12,13 +12,13 @@ You can incorporate `Lightformer` into the environment just like a slot.
 
 ```vue
 <script setup>
-import { Enviroment, LightFormer } from '@tres/cientos'
+import { Environment, Lightformer } from '@tres/cientos'
 </script>
 
 <template>
   <Environment>
     <Lightformer :intensity="0.75" :position="[0, 5, -9]" />
-    <Lightformer from="ring" :rotation-y="-Math.PI / 2" :scale="[10, 10, 1]" />
+    <Lightformer form="ring" :rotation-y="-Math.PI / 2" :scale="[10, 10, 1]" />
   </Environment>
 </template>
 ```
@@ -28,7 +28,7 @@ import { Enviroment, LightFormer } from '@tres/cientos'
 Lightformer inherits from mesh, and its extension parameters include:
 | Prop | Description | Default |
 | :----------- | :------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `from` | `circle`, `ring`, `rect`, or any other Mesh type | `rect` |
+| `form` | `circle`, `ring`, `rect`, or any other Mesh type | `rect` |
 | `intensity` | The intensity of the light | 1 |
 | `color` | The color of the light | `0xffffff` |
 | `args` | The arguments of the Geometry | When using other geometries, set the corresponding arguments |


### PR DESCRIPTION
## What

The Lightformer page's example does not run, and its props table documents a prop that does not exist.

**1. Import names.** The snippet imports `Enviroment` and `LightFormer`:

```vue
import { Enviroment, LightFormer } from '@tres/cientos'
```

Neither is exported — `packages/cientos/src/core/staging/index.ts` exports `Environment` and `Lightformer`, so a copy-paste of the example fails on import. Changed to `Environment` / `Lightformer`.

**2. Wrong prop.** The second instance and the props table use `from`:

```vue
<Lightformer from="ring" :rotation-y="-Math.PI / 2" :scale="[10, 10, 1]" />
```

but the component declares `form` (`'circle' | 'ring' | 'rect' | any`, default `'rect'`) in `packages/cientos/src/core/staging/useEnvironment/lightformer/index.vue`. As written, the value was dropped and you got the default rect instead of a ring — the sibling demo (`apps/cientos-docs/app/components/staging/Lightformer.vue`) already uses `:form`. Fixed in both the snippet and the props table.

**3. Frontmatter grammar.** `Addon for environment component that provided you custom lights.` → `Addon for the Environment component that provides custom lights.`

## Notes

Docs-only change — CI skips markdown-only PRs (`paths-ignore: '**/*.md'` in `.github/workflows/ci.yml`), so there is no build/test impact. No other page imports from `@tres/cientos`, and the same `from`/`form` slip does not appear elsewhere in `apps/cientos-docs`.
