### PR TITLE
docs(cientos): align API docs with current component source

### DIFF
--- a/apps/cientos-docs/content/2.api/1.abstractions/align.md
+++ b/apps/cientos-docs/content/2.api/1.abstractions/align.md
@@ -53,8 +53,13 @@ All props are optional.
 | `disableY`   | If `true`, disables alignment on the y-axis. | `false` |
 | `disableZ`   | If `true`, disables alignment on the z-axis. | `false` |
 | `precise`    | See [Box3.setFromObject](https://threejs.org/docs/index.html?q=box3#api/en/math/Box3.setFromObject). | `true` |
-| `onAlign`    | Callback that fires when updating, after measurement. | |
 | `cacheKey`   | If set, component will only update when `cacheKey`'s value changes. If unset, component will update every frame. | `undefined` |
+
+## Events
+
+| Event    | Payload                | Description                                              |
+| -------- | ---------------------- | -------------------------------------------------------- |
+| `change` | `AlignCallbackOptions` | Fires after measurement, whenever the aligned bounding box or position changes. |
 
 ## AlignCallbackOptions
 

--- a/apps/cientos-docs/content/2.api/3.loaders/2.gltf-model.md
+++ b/apps/cientos-docs/content/2.api/3.loaders/2.gltf-model.md
@@ -8,7 +8,7 @@ description: A component based on useGLTF to load models in TresJS scenes.
   ::
 ::
 
-The `GLTFModel` component is a wrapper around [`useGLTF`](./use-gltf.md) composable and accepts the same options as props.
+The `GLTFModel` component is a wrapper around [`useGLTF`](/api/loaders/use-gltf) composable and accepts the same options as props.
 
 ## Usage
 
@@ -84,14 +84,14 @@ watch(() => modelRef.value?.instance, (gltf) => {
 
 ::prose-note
 `path` is not reactive: the component reads it once on setup. Use
-[`useGLTF`](./use-gltf.md) with a `ref` path if you need to swap models at runtime.
+[`useGLTF`](/api/loaders/use-gltf) with a `ref` path if you need to swap models at runtime.
 ::
 
 ## When to reach for something else
 
 `GLTFModel` renders the model's scene graph as-is, which means there is no element to hang a
 material swap, a click handler or a `v-if` on. When you need that, use
-[`useGLTF`](./use-gltf.md) to compose the parts yourself, or let the
+[`useGLTF`](/api/loaders/use-gltf) to compose the parts yourself, or let the
 [TresJS CLI](https://docs.tresjs.org/cli/gltf) generate a typed component with a slot per node:
 
 ```bash

--- a/apps/cientos-docs/content/2.api/3.loaders/4.fbx-model.md
+++ b/apps/cientos-docs/content/2.api/3.loaders/4.fbx-model.md
@@ -8,7 +8,7 @@ description: A component based on useFBX to load models in TresJS scenes.
   ::
 ::
 
-The `FBXModel` component is a wrapper around [`useFBX`](./use-fbx.md) composable and accepts the same options as props.
+The `FBXModel` component is a wrapper around [`useFBX`](/api/loaders/use-fbx) composable and accepts the same options as props.
 
 ## Usage
 

--- a/apps/cientos-docs/content/2.api/7.light-shadow/accumulative-shadows.md
+++ b/apps/cientos-docs/content/2.api/7.light-shadow/accumulative-shadows.md
@@ -41,16 +41,16 @@ import { TresCanvas } from '@tresjs/core'
 
 | Prop | Description | Default |
 | - | - | - |
-| `once` | Whether shadow creation only happens once (resets after props change) | `false` |
+| `once` | Whether shadow creation only happens once (resets after props change) | `true` |
 | `accumulate` | Whether shadows accumulate progressively over several frames | `true` |
 | `frames` | Number of frames to render. More yields cleaner results but takes more time. If `accumulate && once`, 1 frame will be consumed every update for `frames` updates. Otherwise, `frames` frames are consumed for every update. | `40` |
-| `blend` | If `accumulate`, controls the refresh ratio | `100` |
+| `blend` | If `accumulate`, controls the refresh ratio | `20` |
 | `limit` | If less than `Infinity`, limits the amount of frames rendered. Use this to increase performance once a movable scene has settled | `Infinity` |
 | `scale` | Scale of the plane | `10` |
 | `opacity` | Opacity of the plane | `1` |
 | `alphaTest` | Discards alpha pixels | `0.65` |
 | `color` | Shadow color | `'black'` |
-| `colorBlend` | If less than `Infinity`, limits the amount of frames rendered. Use this to increase performance once a movable scene has settled | `Infinity` |
+| `colorBlend` | Amount of `color` blended into the shadow. `0` is black | `2` |
 | `resolution` | Buffer resolution | `1024` |
 | `toneMapped` | Texture tonemapping | `true` |
 

--- a/apps/cientos-docs/content/2.api/8.staging/1.environment.md
+++ b/apps/cientos-docs/content/2.api/8.staging/1.environment.md
@@ -140,7 +140,6 @@ When `syncMaterials` is enabled:
 | :----------- | :-------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | `files` | Array of 6 urls to images, one for each side of the CubeTexture, or an HDR file | `undefined` |
 | `path` | Path to the environment map files | `undefined` |
-| `encoding` | Encoding of the environment map | `SRGBColorSpace` for array files, `LinearEncoding` for single texture |
 | `background` | If `true`, the environment map will be used as the scene background | `false` |
 | `blur` | Blur factor between 0 and 1 (only works with three 0.146 and up) | 0 |
 | `preset` | Preset environment map | `undefined` |

--- a/apps/cientos-docs/content/2.api/8.staging/2.use-environment.md
+++ b/apps/cientos-docs/content/2.api/8.staging/2.use-environment.md
@@ -21,7 +21,6 @@ UseEnvironment needs to be wrapped by a Suspense component
 ```vue
 <script setup lang="ts">
 import { useEnvironment } from '@tresjs/cientos'
-import { SRGBColorSpace } from 'three'
 
 const texture = await useEnvironment({
   files: [
@@ -33,7 +32,6 @@ const texture = await useEnvironment({
     '/textures/environmentMaps/0/nz.jpg',
   ],
   path: '',
-  encoding: SRGBColorSpace,
 })
 </script>
 ```
@@ -55,7 +53,6 @@ import { useEnvironment } from '@tresjs/cientos'
 const texture = await useEnvironment({
   files: '/sunset.hdr',
   path: '',
-  encoding: SRGBColorSpace,
 })
 ```
 
@@ -63,9 +60,8 @@ const texture = await useEnvironment({
 
 | Name           | Type       | Default                                                                          | Description                                                                 |
 | :------------- | ---------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **files**      | `Array`    | `undefined`                                                                      | Array of 6 urls to images, one for each side of the CubeTexture. or and HDR |
-| **path**       | `boolean`  | `false`                                                                          | Path to the environment map files.                                          |
-| **encoding**   | `Encoding` | `SRGBColorSpace` for an array of files and `LinearEncoding` for a single texture | Encoding of the environment map.                                            |
+| **files**      | `string \| string[]` | `undefined`                                                          | Array of 6 urls to images, one for each side of the CubeTexture, or a single HDR file. |
+| **path**       | `string`   | `''`                                                                             | Path to the environment map files.                                          |
 | **background** | `boolean`  | `false`                                                                          | If `true` the texture will be used as the scene background.                 |
 | **blur**       | `number`   | `0`                                                                              | Blur factor between 0 and 1. (only works with three 0.146 and up)           |
 | **preset**     | `string`   | `undefined`                                                                      | Preset environment map.                                                     |
@@ -74,3 +70,4 @@ const texture = await useEnvironment({
 | **environmentIntensity** | `number` | `1` | Intensity of the environment. |
 | **backgroundRotation** | `VectorFlexibleParams` | `[0, 0, 0]` | Rotation of the background. |
 | **environmentRotation** | `VectorFlexibleParams` | `[0, 0, 0]` | Rotation of the environment. |
+| **syncMaterials** | `boolean` | `false` | If `true`, environment rotation is synced with background rotation. |

--- a/apps/cientos-docs/content/2.api/9.objects/image.md
+++ b/apps/cientos-docs/content/2.api/9.objects/image.md
@@ -44,8 +44,7 @@ import { Image } from '@tresjs/cientos'
 | `zoom`          | Shrinks or enlarges the image texture. | `1` |
 | `radius`        | Border radius applied to the image texture. (Intended for rectangular geometries. Use with `transparent`.) | `0` |
 | `grayscale`        | Power of grayscale effect. 0 is off. 1 is full grayscale. | `0` |
-| `toneMapped`        | Whether this material is tone mapped according to the renderers toneMapping settings. [See THREE.material.tonemapped](https://threejs.org/docs/?q=material#api/en/materials/Material.toneMapped) | `0` |
-| `transparent` |  Whether the image material should be transparent. [See THREE.material.transparent](https://threejs.org/docs/?q=material#api/en/materials/Material.transparent) | `false` |
+| `toneMapped`        | Whether this material is tone mapped according to the renderers toneMapping settings. [See THREE.material.tonemapped](https://threejs.org/docs/?q=material#api/en/materials/Material.toneMapped) | `true` |
 | `transparent` |  Whether the image material should be transparent. [See THREE.material.transparent](https://threejs.org/docs/?q=material#api/en/materials/Material.transparent) | `false` |
 | `opacity` | Opacity of the image material. [See THREE.material.transparent](https://threejs.org/docs/?q=material#api/en/materials/Material.transparent) | `1` |
 | `side` | THREE.Side of the image material. [See THREE.material.side](https://threejs.org/docs/?q=material#api/en/materials/Material.side) | `FrontSide` |


### PR DESCRIPTION
### Description

While going through the cientos docs I noticed a few pages that no longer match the implementation in `packages/cientos`. This PR fixes the props, defaults and links that drifted:

- **align** — `onAlign` is listed as a prop, but the component only declares/emits the `change` event. Removed the stale row and documented the event instead.
- **accumulative-shadows** — `once` defaults to `true` (not `false`) and `blend` to `20` (not `100`). The `colorBlend` row was describing `limit` and carried its default (`Infinity`) instead of `2`.
- **environment** — `encoding` is no longer part of `EnvironmentOptions`, so it is removed from the props table.
- **image** — `toneMapped` defaults to `true` (the docs said `0`), and the `transparent` row was duplicated.
- **use-environment** — `encoding` was removed from the options and from both examples; `files` is `string | string[]`, `path` is a `string` defaulting to `''` (documented as `boolean` / `false`), and `syncMaterials` was missing from the table.
- **gltf-model / fbx-model** — the relative `./use-gltf.md` and `./use-fbx.md` links point to files that do not exist; switched to the API routes used elsewhere in the docs.

### Evidence

Every change is backed by the component source:

| Page | Source |
| --- | --- |
| `align.md` | `packages/cientos/src/core/abstractions/Align.vue` — `defineEmits` + `emit('change', ...)` |
| `accumulative-shadows.md` | `packages/cientos/src/core/light-shadow/AccumulativeShadows/component.vue` — `withDefaults` (`once: true`, `blend: 20`, `colorBlend: 2`) |
| `environment.md` | `packages/cientos/src/core/staging/useEnvironment/const.ts` — no `encoding` in `EnvironmentOptions` |
| `image.md` | `packages/cientos/src/core/objects/Image.vue` — `withDefaults` (`toneMapped: true`) |
| `use-environment.md` | `packages/cientos/src/core/staging/useEnvironment/index.ts` — option destructuring |
| `gltf-model.md` / `fbx-model.md` | the referenced `use-gltf.md` / `use-fbx.md` files do not exist under `content/2.api/3.loaders/` |

Docs-only change, no source or runtime behaviour touched.
