### PR TITLE
fix(core): render mode resync

### DIFF
--- a/apps/docs/content/3.api/2.composables/3.use-loop.md
+++ b/apps/docs/content/3.api/2.composables/3.use-loop.md
@@ -138,6 +138,8 @@ render((notifySuccess) => {
 
 ::warning
 **Success Callback Required**: You must call the provided callback (named `notifySuccess()` in the example above) to properly notify the render loop that the frame was completed. This is essential for the render modes (`always`, `on-demand`, `manual`) to function correctly.
+
+If the render function does not declare the `notifySuccess` parameter, each invocation is treated as a completed frame.
 ::
 
 #### Custom Rendering Examples

--- a/packages/core/src/composables/useRenderer/useRendererManager.test.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.test.ts
@@ -1,0 +1,180 @@
+import type { RendererOptions, RenderMode } from './useRendererManager'
+import type { TresCamera } from '../../types'
+import type { ShallowRef } from 'vue'
+import { mount } from '@vue/test-utils'
+import { Scene } from 'three'
+import { computed, defineComponent, h, nextTick, reactive, ref, shallowRef } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupMocks } from '../../utils/test/mocking'
+import { useCameraManager } from '../useCamera'
+import { useRendererManager } from './useRendererManager'
+
+const createRendererDouble = () => ({
+  domElement: { width: 800, height: 600 },
+  render: vi.fn(),
+  setSize: vi.fn(),
+  setPixelRatio: vi.fn(),
+  getPixelRatio: vi.fn(() => 1),
+  setClearColor: vi.fn(),
+  setClearAlpha: vi.fn(),
+  dispose: vi.fn(),
+  forceContextLoss: vi.fn(),
+  shadowMap: { enabled: false, type: 0 },
+  toneMapping: 0,
+  toneMappingExposure: 1,
+  outputColorSpace: '',
+})
+
+const cleanups: Array<() => void> = []
+
+const createHarness = (renderMode: RenderMode) => {
+  const sizes = {
+    width: ref(800),
+    height: ref(600),
+    pixelRatio: ref(1),
+    aspectRatio: computed(() => 800 / 600),
+  }
+  const camera = useCameraManager({ sizes })
+  camera.registerCamera({ isCamera: true, uuid: 'camera-double' } as unknown as TresCamera)
+
+  const scene = shallowRef(new Scene()) as ShallowRef<never>
+  const canvas = ref(document.createElement('canvas'))
+  const renderer = createRendererDouble()
+  const options = reactive<RendererOptions>({
+    renderMode,
+    renderer: () => renderer as never,
+  })
+
+  const manager = useRendererManager({
+    scene,
+    canvas,
+    options,
+    contextParts: { sizes, camera },
+  })
+
+  return { manager, options, renderer }
+}
+
+const mountHarness = async (renderMode: RenderMode) => {
+  let harness!: ReturnType<typeof createHarness>
+  const wrapper = mount(defineComponent({
+    setup() {
+      harness = createHarness(renderMode)
+      return () => h('div')
+    },
+  }))
+  cleanups.push(() => wrapper.unmount())
+
+  await nextTick()
+  await nextTick()
+  await nextTick()
+
+  return harness
+}
+
+describe('useRendererManager render-mode lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanups.splice(0).forEach(cleanup => cleanup())
+    vi.useRealTimers()
+  })
+
+  it('on-demand renders the initial frame and then idles', async () => {
+    const { manager, renderer } = await mountHarness('on-demand')
+    expect(manager.loop.isActive.value).toBe(true)
+
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes rendering when renderMode switches from on-demand to always after draining', async () => {
+    const { options, renderer } = await mountHarness('on-demand')
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(1)
+
+    options.renderMode = 'always'
+    await nextTick()
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(4)
+  })
+
+  it('resumes rendering when renderMode switches from manual to always after draining', async () => {
+    const { manager, options, renderer } = await mountHarness('manual')
+
+    manager.advance()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(1)
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(1)
+
+    options.renderMode = 'always'
+    await nextTick()
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(3)
+  })
+
+  it('drains to idle when renderMode switches from always to on-demand', async () => {
+    const { options, renderer } = await mountHarness('always')
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(2)
+
+    options.renderMode = 'on-demand'
+    await nextTick()
+
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(3)
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(renderer.render).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('tres-canvas render-mode switching (integration)', () => {
+  it('switching render-mode on-demand to always resumes the loop', async () => {
+    vi.resetModules()
+    await setupMocks()
+    const TresCanvas = (await import('../../components/TresCanvas.vue')).default
+
+    const renderMode = ref<'always' | 'on-demand'>('on-demand')
+    let renderCount = 0
+
+    const wrapper = mount(defineComponent({
+      setup: () => () => h(TresCanvas, {
+        windowSize: true,
+        renderMode: renderMode.value,
+        onRender: () => {
+          renderCount++
+        },
+      }),
+    }), { attachTo: document.body })
+
+    await vi.waitFor(() => expect(renderCount).toBeGreaterThan(0))
+    const idleCount = renderCount
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(renderCount).toBe(idleCount)
+
+    renderMode.value = 'always'
+    await nextTick()
+
+    await vi.waitFor(() => expect(renderCount).toBeGreaterThan(idleCount))
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/composables/useRenderer/useRendererManager.test.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.test.ts
@@ -143,6 +143,51 @@ describe('useRendererManager render-mode lifecycle', () => {
     vi.advanceTimersToNextFrame()
     expect(renderer.render).toHaveBeenCalledTimes(3)
   })
+
+  it('on-demand settles when the custom render function does not declare notifySuccess', async () => {
+    const { manager } = await mountHarness('on-demand')
+
+    const customRender = vi.fn(() => {})
+    manager.replaceRenderFunction(customRender)
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(customRender).toHaveBeenCalledTimes(1)
+  })
+
+  it('always keeps calling a custom render function without notifySuccess every frame', async () => {
+    const { manager } = await mountHarness('always')
+
+    const customRender = vi.fn(() => {})
+    manager.replaceRenderFunction(customRender)
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(customRender).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps the explicit notifySuccess contract for render functions that declare it', async () => {
+    const { manager } = await mountHarness('on-demand')
+
+    const notifyingRender = vi.fn((notifySuccess: () => void) => {
+      notifySuccess()
+    })
+    manager.replaceRenderFunction(notifyingRender)
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(notifyingRender).toHaveBeenCalledTimes(1)
+
+    const nonNotifyingRender = vi.fn((_notifySuccess: () => void) => {})
+    manager.replaceRenderFunction(nonNotifyingRender)
+    manager.invalidate()
+
+    vi.advanceTimersToNextFrame()
+    vi.advanceTimersToNextFrame()
+    expect(nonNotifyingRender).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('tres-canvas render-mode switching (integration)', () => {

--- a/packages/core/src/composables/useRenderer/useRendererManager.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.ts
@@ -335,6 +335,20 @@ export function useRendererManager(
   }
 
   const replaceRenderFunction = (fn: RenderFunction) => {
+    if (fn.length === 0) {
+      renderFunction = () => {
+        const result = (fn as () => unknown)()
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          (result as Promise<unknown>).then(notifyFrameRendered, notifyFrameRendered)
+        }
+        else {
+          notifyFrameRendered()
+        }
+      }
+
+      return
+    }
+
     renderFunction = fn
   }
 

--- a/packages/core/src/composables/useRenderer/useRendererManager.ts
+++ b/packages/core/src/composables/useRenderer/useRendererManager.ts
@@ -269,6 +269,10 @@ export function useRendererManager(
 
   const isModeAlways = computed(() => toValue(options.renderMode) === 'always')
 
+  watch(() => toValue(options.renderMode), (renderMode) => {
+    frames.value = renderMode === 'manual' ? 0 : 1
+  })
+
   const readyEventHook = createEventHook<TresRenderer>()
   const errorEventHook = createEventHook<TresRendererError>()
   let hasTriggeredReady = false


### PR DESCRIPTION
## Summary

Fixes #1487: two frame-budget lifecycle bugs in `useRendererManager` that break the `on-demand`/`manual` render modes.

1. **Switching `renderMode` could permanently freeze rendering.** Once the internal frame budget (`frames`) drained to 0, switching to `always` never rendered again: `notifyFrameRendered` is the only place that re-arms the budget for `always`, but it can only run from inside the render function, and the loop only invokes the render function while `frames > 0`. There is no watcher on `renderMode`.
2. **Custom render functions without `notifySuccess` never settled.** A function registered through `useLoop().render(fn)` that does not declare the `notifySuccess` parameter (e.g. `render(() => composer.render())`) cannot report completion, so `on-demand`/`manual` kept the budget at 1 and rendered every frame.

## Changes

| Commit | Change |
| --- | --- |
| `fix(core): resync frame budget when renderMode changes` | Watcher resets `frames` on every mode change: `manual` -> `0`, `always`/`on-demand` -> `1` |
| `fix(core): settle on-demand frames when notifySuccess is omitted` | Zero-argument render functions count as one completed frame per invocation (awaits the returned promise when there is one); functions declaring `notifySuccess` keep the explicit contract |

Also:
- Documents the zero-argument behavior in the `useLoop` guide (`apps/docs`).
- Adds the first `renderMode` test coverage in `packages/core` (8 tests).

No breaking changes: behavior is unchanged for render functions that declare `notifySuccess`.

## How to test

```bash
pnpm --filter @tresjs/core test:ci
pnpm --filter @tresjs/core lint
pnpm --filter @tresjs/core build
```

| Scenario | Before | After |
| --- | --- | --- |
| `on-demand` -> `always` after the budget drained | frozen (1 render total) | resumes (4 renders over 3 frames) |
| `manual` -> `always` after the budget drained | frozen | resumes |
| `on-demand` + render function without `notifySuccess` | renders every frame | settles after 1 frame |
| `always` + render function without `notifySuccess` | renders every frame | unchanged |
| render function declaring `notifySuccess` | contract unchanged | contract unchanged |

Browser check (WebGL2, `:render-mode` toggled at runtime, 3 s window after the switch):

| Build | Idle -> `always` |
| --- | --- |
| Before (current `main`) | `renders 1 -> 1` (frozen) |
| After | `renders 1 -> 720` |


## Checklist

- [x] `pnpm --filter @tresjs/core test:ci` - 22 files, 644 passed, 3 skipped
- [x] `pnpm --filter @tresjs/core lint` - exit 0
- [x] `pnpm --filter @tresjs/core build` - exit 0
- [x] Docs updated
- [x] No breaking changes

## Notes

- The two commits are independent; happy to split them into separate PRs if separate review is preferred.
- Related to #1220: that issue tracks the rAF loop continuing to tick while idle (CPU usage). This PR does not change loop pausing; it fixes the opposite failure, where the loop stops rendering entirely after a mode switch.
- `pnpm typecheck` on the monorepo still reports 2 pre-existing errors in `useLoader/component.vue` on `main`; unchanged by this PR.